### PR TITLE
Fix broken kickoff script

### DIFF
--- a/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -41,7 +41,7 @@ Check Working Dir
     ${wd_level_len}=  Get Length  ${wd_split}
     ${last_level_idx}=  Evaluate  ${wd_level_len} - 1
     ${current_folder}=  Get From List  ${wd_split}  ${last_level_idx}
-    Run Keyword Unless  '${current_folder}' == 'vic'  Fatal Error  Test script should be run from vic/
+    Run Keyword Unless  '${current_folder}' == 'vic-ui'  Fatal Error  Test script should be run from vic-ui/
 
 Check Drone
     ${rc}  ${drone_ver}=  Run And Return Rc And Output  drone --version 2>&1


### PR DESCRIPTION
The kickoff script enforces the root folder of the project
to be 'vic', however the VIC UI has branched off it with a
new name 'vic-ui', the script always fails to start. This commit
fixes the issue.

Fixes #6 