### PR TITLE
Set up integration tests with the vic-ui repository

### DIFF
--- a/.drone.local.plugin.yml
+++ b/.drone.local.plugin.yml
@@ -14,9 +14,6 @@ pipeline:
       BIN: bin
       GOPATH: /go
       SHELL: /bin/bash
-      NIMBUS_USER: ${NIMBUS_USER}
-      NIMBUS_PASSWORD: ${NIMBUS_PASSWORD}
-      NIMBUS_GW: ${NIMBUS_GW}
       TEST_DATASTORE: ${TEST_DATASTORE}
       TEST_RESOURCE: ${TEST_RESOURCE}
       GOVC_INSECURE: true

--- a/.drone.local.script.yml
+++ b/.drone.local.script.yml
@@ -14,9 +14,6 @@ pipeline:
       BIN: bin
       GOPATH: /go
       SHELL: /bin/bash
-      NIMBUS_USER: ${NIMBUS_USER}
-      NIMBUS_PASSWORD: ${NIMBUS_PASSWORD}
-      NIMBUS_GW: ${NIMBUS_GW}
       TEST_DATASTORE: ${TEST_DATASTORE}
       TEST_RESOURCE: ${TEST_RESOURCE}
       GOVC_INSECURE: true

--- a/tests/manual-test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
@@ -27,7 +27,6 @@ ${REMOTE_RESULTS_FOLDER}  /tmp/vic-ui-e2e-installer
 Load Testbed Information And Force Remove Vicui Plugin
     # load nimbus & vch testbed information from testbed-information
     Load Nimbus Testbed Env
-    Load Secrets  ../../../test.secrets
     Force Remove Vicui Plugin
     Set Absolute Script Paths
 

--- a/tests/manual-test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
@@ -183,7 +183,7 @@ TestCase-Install Plugin Successfully
 # Run the test cases above in macOS
 Run Testcases On Mac
     ${results_folder}=  Set Variable  ../../../%{TEST_RESULTS_FOLDER}
-    ${remote_vic_root}=  Set Variable  /Users/browseruser/Desktop/vic
+    ${remote_vic_root}=  Set Variable  /Users/browseruser/Desktop/vic-ui
     ${remote_scratch_folder}=  Set Variable  /tmp/vic-ui-e2e-scratch
     OperatingSystem.Create Directory  ${results_folder}
 
@@ -192,7 +192,6 @@ Run Testcases On Mac
     Login  ${MACOS_HOST_USER}  ${MACOS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
     Put File  testbed-information  ${remote_vic_root}/tests/manual-test-cases/Group18-VIC-UI/  mode=0700
-    Put File  ../../../test.secrets  ${remote_vic_root}/
     Put File  ../../../ui-nightly-run-bin/vic-ui-darwin  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${MACOS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${MACOS_HOST_USER}@${MACOS_HOST_IP}:${remote_scratch_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
@@ -236,7 +235,7 @@ Run Testcases On Mac
 # Run the test cases above in Windows
 Run Testcases On Windows
     ${results_folder}=  Set Variable  ../../../%{TEST_RESULTS_FOLDER}
-    ${remote_vic_root}=  Set Variable  /cygdrive/c/Users/IEUser/vic
+    ${remote_vic_root}=  Set Variable  /cygdrive/c/Users/IEUser/vic-ui
     ${remote_scratch_folder}=  Set Variable  /tmp/vic-ui-e2e-scratch
     OperatingSystem.Create Directory  ${results_folder}
 
@@ -245,7 +244,6 @@ Run Testcases On Windows
     Login  ${WINDOWS_HOST_USER}  ${WINDOWS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
     Put File  testbed-information  ${remote_vic_root}/tests/manual-test-cases/Group18-VIC-UI/
-    Put File  ../../../test.secrets  ${remote_vic_root}/
     Put File  ../../../scripts/plugin-manifest  ${remote_vic_root}/scripts/
     Put File  ../../../vic-ui-windows.exe  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_scratch_folder} 2>&1

--- a/tests/manual-test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
@@ -197,11 +197,12 @@ Run Testcases On Mac
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     # update local repo
+    # TODO: replace vic-6548 with master once the branch gets merged
     ${update_repo_command}=  Catenate
     ...  mkdir -p ${REMOTE_RESULTS_FOLDER} &&
     ...  cd ${remote_vic_root} &&
     ...  git remote update &&
-    ...  git checkout -f jooskim/new-master
+    ...  git checkout -f jooskim/vic-6548
     ${stdout}  ${stderr}  ${rc}=  Execute Command  ${update_repo_command}  return_stderr=True  return_rc=True
     Run Keyword Unless  ${rc} == 0  Log To Console  ${stderr}
 
@@ -253,10 +254,11 @@ Run Testcases On Windows
     Execute Command  mkdir -p ${REMOTE_RESULTS_FOLDER}
 
     # remotely run robot test
+    # TODO: replace vic-6548 with master once the branch gets merged
     ${ssh_command}=  Catenate
     ...  cd ${remote_vic_root} &&
     ...  git remote update &&
-    ...  git checkout -f jooskim/new-master &&
+    ...  git checkout -f jooskim/vic-6548 &&
     ...  cd tests/manual-test-cases/Group18-VIC-UI &&
     ...  robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-1-VIC-UI-Installer.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
     ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True

--- a/tests/manual-test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
@@ -197,12 +197,11 @@ Run Testcases On Mac
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     # update local repo
-    # TODO: replace vic-6548 with master once the branch gets merged
     ${update_repo_command}=  Catenate
     ...  mkdir -p ${REMOTE_RESULTS_FOLDER} &&
     ...  cd ${remote_vic_root} &&
     ...  git remote update &&
-    ...  git checkout -f jooskim/vic-6548
+    ...  git checkout -f master
     ${stdout}  ${stderr}  ${rc}=  Execute Command  ${update_repo_command}  return_stderr=True  return_rc=True
     Run Keyword Unless  ${rc} == 0  Log To Console  ${stderr}
 
@@ -254,11 +253,10 @@ Run Testcases On Windows
     Execute Command  mkdir -p ${REMOTE_RESULTS_FOLDER}
 
     # remotely run robot test
-    # TODO: replace vic-6548 with master once the branch gets merged
     ${ssh_command}=  Catenate
     ...  cd ${remote_vic_root} &&
     ...  git remote update &&
-    ...  git checkout -f jooskim/vic-6548 &&
+    ...  git checkout -f master &&
     ...  cd tests/manual-test-cases/Group18-VIC-UI &&
     ...  robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-1-VIC-UI-Installer.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
     ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True

--- a/tests/manual-test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
@@ -209,11 +209,12 @@ Run Testcases On Mac
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     # update local repo
+    # TODO: replace vic-6548 with master once the branch gets merged
     ${update_repo_command}=  Catenate
     ...  mkdir -p ${REMOTE_RESULTS_FOLDER} &&
     ...  cd ${remote_vic_root} &&
     ...  git remote update &&
-    ...  git checkout -f jooskim/new-master
+    ...  git checkout -f jooskim/vic-6548
     ${stdout}  ${stderr}  ${rc}=  Execute Command  ${update_repo_command}  return_stderr=True  return_rc=True
     Run Keyword Unless  ${rc} == 0  Log To Console  ${stderr}
 
@@ -265,10 +266,11 @@ Run Testcases On Windows
     Execute Command  mkdir -p ${REMOTE_RESULTS_FOLDER}
 
     # remotely run robot test
+    # TODO: replace vic-6548 with master once the branch gets merged
     ${ssh_command}=  Catenate
     ...  cd ${remote_vic_root} &&
     ...  git remote update &&
-    ...  git checkout -f jooskim/new-master &&
+    ...  git checkout -f jooskim/vic-6548 &&
     ...  cd tests/manual-test-cases/Group18-VIC-UI &&
     ...  robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-2-VIC-UI-Uninstaller.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
     ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True

--- a/tests/manual-test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
@@ -27,7 +27,6 @@ ${REMOTE_RESULTS_FOLDER}  /tmp/vic-ui-e2e-uninstaller
 Load Testbed Information And Force Install Vicui Plugin
     # load nimbus & vch testbed information from testbed-information
     Load Nimbus Testbed Env
-    Load Secrets  ../../../test.secrets
     Set Absolute Script Paths
     Force Install Vicui Plugin
 

--- a/tests/manual-test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
@@ -195,7 +195,7 @@ TestCase-Attempt To Uninstall Plugin That Is Already Gone
 # Run the test cases above in macOS
 Run Testcases On Mac
     ${results_folder}=  Set Variable  ../../../%{TEST_RESULTS_FOLDER}
-    ${remote_vic_root}=  Set Variable  /Users/browseruser/Desktop/vic
+    ${remote_vic_root}=  Set Variable  /Users/browseruser/Desktop/vic-ui
     ${remote_scratch_folder}=  Set Variable  /tmp/vic-ui-e2e-scratch
     OperatingSystem.Create Directory  ${results_folder}
 
@@ -204,7 +204,6 @@ Run Testcases On Mac
     Login  ${MACOS_HOST_USER}  ${MACOS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
     Put File  testbed-information  ${remote_vic_root}/tests/manual-test-cases/Group18-VIC-UI/  mode=0700
-    Put File  ../../../test.secrets  ${remote_vic_root}/
     Put File  ../../../ui-nightly-run-bin/vic-ui-darwin  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${MACOS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${MACOS_HOST_USER}@${MACOS_HOST_IP}:${remote_scratch_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
@@ -248,7 +247,7 @@ Run Testcases On Mac
 # Run the test cases above in Windows
 Run Testcases On Windows
     ${results_folder}=  Set Variable  ../../../%{TEST_RESULTS_FOLDER}
-    ${remote_vic_root}=  Set Variable  /cygdrive/c/Users/IEUser/vic
+    ${remote_vic_root}=  Set Variable  /cygdrive/c/Users/IEUser/vic-ui
     ${remote_scratch_folder}=  Set Variable  /tmp/vic-ui-e2e-scratch
     OperatingSystem.Create Directory  ${results_folder}
 
@@ -257,7 +256,6 @@ Run Testcases On Windows
     Login  ${WINDOWS_HOST_USER}  ${WINDOWS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
     Put File  testbed-information  ${remote_vic_root}/tests/manual-test-cases/Group18-VIC-UI/
-    Put File  ../../../test.secrets  ${remote_vic_root}/
     Put File  ../../../scripts/plugin-manifest  ${remote_vic_root}/scripts/
     Put File  ../../../vic-ui-windows.exe  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_scratch_folder} 2>&1

--- a/tests/manual-test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
@@ -209,12 +209,11 @@ Run Testcases On Mac
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     # update local repo
-    # TODO: replace vic-6548 with master once the branch gets merged
     ${update_repo_command}=  Catenate
     ...  mkdir -p ${REMOTE_RESULTS_FOLDER} &&
     ...  cd ${remote_vic_root} &&
     ...  git remote update &&
-    ...  git checkout -f jooskim/vic-6548
+    ...  git checkout -f master
     ${stdout}  ${stderr}  ${rc}=  Execute Command  ${update_repo_command}  return_stderr=True  return_rc=True
     Run Keyword Unless  ${rc} == 0  Log To Console  ${stderr}
 
@@ -266,11 +265,10 @@ Run Testcases On Windows
     Execute Command  mkdir -p ${REMOTE_RESULTS_FOLDER}
 
     # remotely run robot test
-    # TODO: replace vic-6548 with master once the branch gets merged
     ${ssh_command}=  Catenate
     ...  cd ${remote_vic_root} &&
     ...  git remote update &&
-    ...  git checkout -f jooskim/vic-6548 &&
+    ...  git checkout -f master &&
     ...  cd tests/manual-test-cases/Group18-VIC-UI &&
     ...  robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-2-VIC-UI-Uninstaller.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
     ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True

--- a/tests/manual-test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
@@ -206,7 +206,7 @@ TestCase-Upgrade When Plugins Are Already Installed
 # Run the test cases above in macOS
 Run Testcases On Mac
     ${results_folder}=  Set Variable  ../../../%{TEST_RESULTS_FOLDER}
-    ${remote_vic_root}=  Set Variable  /Users/browseruser/Desktop/vic
+    ${remote_vic_root}=  Set Variable  /Users/browseruser/Desktop/vic-ui
     ${remote_scratch_folder}=  Set Variable  /tmp/vic-ui-e2e-scratch
     OperatingSystem.Create Directory  ${results_folder}
 
@@ -215,7 +215,6 @@ Run Testcases On Mac
     Login  ${MACOS_HOST_USER}  ${MACOS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
     Put File  testbed-information  ${remote_vic_root}/tests/manual-test-cases/Group18-VIC-UI/  mode=0700
-    Put File  ../../../test.secrets  ${remote_vic_root}/
     Put File  ../../../ui-nightly-run-bin/vic-ui-darwin  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${MACOS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${MACOS_HOST_USER}@${MACOS_HOST_IP}:${remote_scratch_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
@@ -259,7 +258,7 @@ Run Testcases On Mac
 # Run the test cases above in Windows
 Run Testcases On Windows
     ${results_folder}=  Set Variable  ../../../%{TEST_RESULTS_FOLDER}
-    ${remote_vic_root}=  Set Variable  /cygdrive/c/Users/IEUser/vic
+    ${remote_vic_root}=  Set Variable  /cygdrive/c/Users/IEUser/vic-ui
     ${remote_scratch_folder}=  Set Variable  /tmp/vic-ui-e2e-scratch
     OperatingSystem.Create Directory  ${results_folder}
 
@@ -268,7 +267,6 @@ Run Testcases On Windows
     Login  ${WINDOWS_HOST_USER}  ${WINDOWS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
     Put File  testbed-information  ${remote_vic_root}/tests/manual-test-cases/Group18-VIC-UI/
-    Put File  ../../../test.secrets  ${remote_vic_root}/
     Put File  ../../../scripts/plugin-manifest  ${remote_vic_root}/scripts/
     Put File  ../../../vic-ui-windows.exe  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_scratch_folder} 2>&1

--- a/tests/manual-test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
@@ -220,11 +220,12 @@ Run Testcases On Mac
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     # update local repo
+    # TODO: replace vic-6548 with master once the branch gets merged
     ${update_repo_command}=  Catenate
     ...  mkdir -p ${REMOTE_RESULTS_FOLDER} &&
     ...  cd ${remote_vic_root} &&
     ...  git remote update &&
-    ...  git checkout -f jooskim/new-master
+    ...  git checkout -f jooskim/vic-6548
     ${stdout}  ${stderr}  ${rc}=  Execute Command  ${update_repo_command}  return_stderr=True  return_rc=True
     Run Keyword Unless  ${rc} == 0  Log To Console  ${stderr}
 
@@ -276,10 +277,11 @@ Run Testcases On Windows
     Execute Command  mkdir -p ${REMOTE_RESULTS_FOLDER}
 
     # remotely run robot test
+    # TODO: replace vic-6548 with master once the branch gets merged
     ${ssh_command}=  Catenate
     ...  cd ${remote_vic_root} &&
     ...  git remote update &&
-    ...  git checkout -f jooskim/new-master &&
+    ...  git checkout -f jooskim/vic-6548 &&
     ...  cd tests/manual-test-cases/Group18-VIC-UI &&
     ...  robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-3-VIC-UI-Upgrader.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
     ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True

--- a/tests/manual-test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
@@ -220,12 +220,11 @@ Run Testcases On Mac
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     # update local repo
-    # TODO: replace vic-6548 with master once the branch gets merged
     ${update_repo_command}=  Catenate
     ...  mkdir -p ${REMOTE_RESULTS_FOLDER} &&
     ...  cd ${remote_vic_root} &&
     ...  git remote update &&
-    ...  git checkout -f jooskim/vic-6548
+    ...  git checkout -f master
     ${stdout}  ${stderr}  ${rc}=  Execute Command  ${update_repo_command}  return_stderr=True  return_rc=True
     Run Keyword Unless  ${rc} == 0  Log To Console  ${stderr}
 
@@ -277,11 +276,10 @@ Run Testcases On Windows
     Execute Command  mkdir -p ${REMOTE_RESULTS_FOLDER}
 
     # remotely run robot test
-    # TODO: replace vic-6548 with master once the branch gets merged
     ${ssh_command}=  Catenate
     ...  cd ${remote_vic_root} &&
     ...  git remote update &&
-    ...  git checkout -f jooskim/vic-6548 &&
+    ...  git checkout -f master &&
     ...  cd tests/manual-test-cases/Group18-VIC-UI &&
     ...  robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-3-VIC-UI-Upgrader.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
     ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True

--- a/tests/manual-test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
@@ -27,7 +27,6 @@ ${REMOTE_RESULTS_FOLDER}  /tmp/vic-ui-e2e-upgrader
 Load Testbed Information And Force Remove Vicui Plugin
     # load nimbus & vch testbed information from testbed-information
     Load Nimbus Testbed Env
-    Load Secrets  ../../../test.secrets
     Force Remove Vicui Plugin
     Set Absolute Script Paths
 

--- a/tests/manual-test-cases/Group18-VIC-UI/18-4-VIC-UI-Plugin-tests.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-4-VIC-UI-Plugin-tests.robot
@@ -22,7 +22,6 @@ Suite Setup  Load Testbed Information And Force Install Vicui Plugin
 *** Keywords ***
 Load Testbed Information And Force Install Vicui Plugin
     Load Nimbus Testbed Env
-    Load Secrets  ../../../test.secrets
     Set Absolute Script Paths
     Force Install Vicui Plugin
 
@@ -102,7 +101,7 @@ Set Up Testbed For HSUIA
     ...  VC_ADMIN_DOMAIN=vsphere.local
     ...  VC_ADMIN_PW=%{TEST_PASSWORD}
     ...  HOST_IP=%{ESX_HOST_IP}
-    ...  HOST_DATASTORE_NAME=%{TEST_DATASTORE}
+    ...  HOST_DATASTORE_NAME=${TEST_DATASTORE}
     ...  H5C_IP=%{TEST_VC_IP}
     ...  H5C_PORT=443
     ...  SELENIUM_IP=%{SELENIUM_SERVER_IP}
@@ -117,11 +116,9 @@ Set Up Testbed For HSUIA
 Set Up Testbed For NGCTESTS
     Environment Variable Should Be Set  SELENIUM_SERVER_IP
     Environment Variable Should Be Set  SELENIUM_BROWSER
-    Environment Variable Should Be Set  TEST_DATASTORE
-    Environment Variable Should Be Set  TEST_RESOURCE
     Environment Variable Should Be Set  ESX_HOST_IP
     Environment Variable Should Be Set  TEST_VC_IP
-    ${ESX_HOST_PASSWORD}=  Set Variable  e2eFunctionalTest
+    ${ESX_HOST_PASSWORD}=  Set Variable  ca*hc0w
     ${TEST_VC_USERNAME}=   Set Variable  administrator@vsphere.local
     ${TEST_VC_PASSWORD}=   Set Variable  Admin\!23
 

--- a/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -90,6 +90,7 @@ Sync Vic Ui Version With Vic Repo
     ${full_ver_string}=  Run  ${vic_machine_binary} version | awk '{print $3}' | sed -e 's/\-rc[[:digit:]]//g'
     ${major_minor_patch}=  Run  echo ${full_ver_string} | awk -F- '{print $1}' | cut -c 2-
     ${build_number}=  Run  echo ${full_ver_string} | awk -F- '{print $2}'
+    ${original_wd}=  Run  pwd
 
     Run  sed 's/version=.*/version=\"${major_minor_patch}\.${build_number}\"/' ui-nightly-run-bin/ci/ui/plugin-manifest > scripts/plugin-manifest
     Run  cp -rf ui-nightly-run-bin/ci/ui/plugin-packages/* scripts/plugin-packages/
@@ -102,8 +103,8 @@ Sync Vic Ui Version With Vic Repo
     Move File  /tmp/plugin-bundle-flex.xml  scripts/vsphere-client-serenity/com.vmware.vic.ui-v.${tmp_build_number}/plugin-package.xml
     Run  mv scripts/plugin-packages/com.vmware.vic-v.${tmp_build_number} scripts/plugin-packages/com.vmware.vic-v${major_minor_patch}.${build_number}
     Run  mv scripts/vsphere-client-serenity/com.vmware.vic.ui-v.${tmp_build_number} scripts/vsphere-client-serenity/com.vmware.vic.ui-v${major_minor_patch}.${build_number}
-    Run  zip -9 -r scripts/plugin-packages/com.vmware.vic-v${major_minor_patch}.${build_number}.zip scripts/plugin-packages/com.vmware.vic-v${major_minor_patch}.${build_number}/*
-    Run  zip -9 -r scripts/vsphere-client-serenity/com.vmware.vic.ui-v${major_minor_patch}.${build_number}.zip scripts/vsphere-client-serenity/com.vmware.vic.ui-v${major_minor_patch}.${build_number}/*
+    Run  cd scripts/plugin-packages/com.vmware.vic-v${major_minor_patch}.${build_number} && zip -9 -r ../com.vmware.vic-v${major_minor_patch}.${build_number}.zip ./* && cd ${original_wd}
+    Run  cd scripts/vsphere-client-serenity/com.vmware.vic.ui-v${major_minor_patch}.${build_number} && zip -9 -r ../com.vmware.vic.ui-v${major_minor_patch}.${build_number}.zip ./* && cd ${original_wd}
 
 Build Flex And H5 Plugins
     # ensure build tools are accessible

--- a/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -193,6 +193,8 @@ Run Script Test With Config
     ${vc_build}=    Get From List  ${config}  2
     ${os}=          Get From List  ${config}  3
     Set Environment Variable  TEST_VSPHERE_VER  ${vc_version}
+    Set Environment Variable  TEST_ESX_BUILD  ${esx_build}
+    Set Environment Variable  TEST_VCSA_BUILD  ${vc_build}
     Set Environment Variable  TEST_OS  ${os}
 
     Log To Console  ${\n}........................................
@@ -252,6 +254,8 @@ Run Plugin Test With Config
     ${selenium_browser}=             Get From List  ${config}  4
     ${selenium_browser_normalized}=  Get From List  ${config}  5
     Set Environment Variable  TEST_VSPHERE_VER  ${vc_version}
+    Set Environment Variable  TEST_ESX_BUILD  ${esx_build}
+    Set Environment Variable  TEST_VCSA_BUILD  ${vc_build}
     Set Environment Variable  TEST_OS  ${os}
 
     Log To Console  ${\n}........................................

--- a/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -76,7 +76,7 @@ Prepare VIC Engine Binaries
     Prepare Flex And H5 Plugins For Testing
 
 Prepare Flex And H5 Plugins For Testing
-    Run Keyword If  ${IS_NIGHTLY_TEST}  Run  cp -rf ui-nightly-run-bin/ci/ui/* scripts/  ELSE  Build Flex And H5 Plugins
+    Run Keyword If  ${IS_NIGHTLY_TEST}  Run  cp -rf ui-nightly-run-bin/ui/* scripts/  ELSE  Build Flex And H5 Plugins
     # TODO: remove the following line and the keyword being called once the build number of vic-ui is in sync with vic repo
     Run Keyword If  ${BUILD_VER_ISSUE_WORKAROUND}  Sync Vic Ui Version With Vic Repo
     # scp plugin binaries to the test file server
@@ -92,9 +92,9 @@ Sync Vic Ui Version With Vic Repo
     ${build_number}=  Run  echo ${full_ver_string} | awk -F- '{print $2}'
     ${original_wd}=  Run  pwd
 
-    Run  sed 's/version=.*/version=\"${major_minor_patch}\.${build_number}\"/' ui-nightly-run-bin/ci/ui/plugin-manifest > scripts/plugin-manifest
-    Run  cp -rf ui-nightly-run-bin/ci/ui/plugin-packages/* scripts/plugin-packages/
-    Run  cp -rf ui-nightly-run-bin/ci/ui/vsphere-client-serenity/* scripts/vsphere-client-serenity/
+    Run  sed 's/version=.*/version=\"${major_minor_patch}\.${build_number}\"/' ui-nightly-run-bin/ui/plugin-manifest > scripts/plugin-manifest
+    Run  cp -rf ui-nightly-run-bin/ui/plugin-packages/* scripts/plugin-packages/
+    Run  cp -rf ui-nightly-run-bin/ui/vsphere-client-serenity/* scripts/vsphere-client-serenity/
 
     ${tmp_build_number}=  Run  echo ${LATEST_VIC_UI_TARBALL} | grep -o "[[:digit:]]\\+"
     Run  sed 's/vic" version="\.${tmp_build_number}"/vic" version="${major_minor_patch}\.${build_number}"/' scripts/plugin-packages/com.vmware.vic-v.${tmp_build_number}/plugin-package.xml > /tmp/plugin-bundle-h5c.xml

--- a/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -257,7 +257,7 @@ Run Script Test With Config
     Should Be Equal As Integers  ${rc}  0
 
     # run drone
-    ${drone-exec-string}=  Set Variable  drone exec --timeout \"1h0m0s\" --timeout.inactivity \"1h0m0s\" --repo.trusted --secrets-file \"test.secrets\" .drone.local.tests.yml
+    ${drone-exec-string}=  Set Variable  drone exec --timeout \"1h0m0s\" --timeout.inactivity \"1h0m0s\" --repo.trusted .drone.local.tests.yml
     ${pid}=  Start Process  bash  -c  ${drone-exec-string}  stdout=${test_results_folder}/stdout.log  stderr=STDOUT
     ${docker-ps}=  Wait Until Keyword Succeeds  30x  5s  Get Integration Container Id
     Log To Console  Drone worker \@ ${docker-ps}
@@ -321,7 +321,7 @@ Run Plugin Test With Config
     Set To Dictionary  ${PLUGIN_TEST_RESULTS_DICT}  ${dict_key}  ❌ Plugin test / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os} / ${selenium_browser_normalized}
 
     # run drone
-    ${drone-exec-string}=  Set Variable  drone exec --timeout \"1h0m0s\" --timeout.inactivity \"1h0m0s\" --repo.trusted --secrets-file \"test.secrets\" .drone.local.tests.yml
+    ${drone-exec-string}=  Set Variable  drone exec --timeout \"1h0m0s\" --timeout.inactivity \"1h0m0s\" --repo.trusted .drone.local.tests.yml
     ${pid}=  Start Process  bash  -c  ${drone-exec-string}  stdout=${test_results_folder}/stdout.log  stderr=STDOUT
     ${docker-ps}=  Wait Until Keyword Succeeds  30x  5s  Get Integration Container Id
     Log To Console  Drone worker \@ ${docker-ps}

--- a/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -31,7 +31,6 @@ Prepare Testbed
     Cleanup Previous Test Logs
     Check Working Dir
     Check Drone
-    Load Secrets
     Get Latest Vic Engine Binary
     Setup Test Matrix
 

--- a/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -23,6 +23,7 @@ Resource         ./vicui-common.robot
 ${TEST_SCRIPTS_ROOT}     tests/manual-test-cases/Group18-VIC-UI/
 ${VICTEST2XL}            ${TEST_SCRIPTS_ROOT}/victest2xl.py
 ${IS_NIGHTLY_TEST}       ${TRUE}
+${BUILD_VER_ISSUE_WORKAROUND}  ${TRUE}
 
 *** Keywords ***
 Prepare Testbed
@@ -66,17 +67,43 @@ Prepare VIC Engine Binaries
     Log  Extracting binary files...
     ${rc1}=  Run And Return Rc  mkdir -p ui-nightly-run-bin
     ${rc2}=  Run And Return Rc  tar xvzf ${LATEST_VIC_ENGINE_TARBALL} -C ui-nightly-run-bin --strip 1
+    ${rc3}=  Run And Return Rc  tar xvzf ${LATEST_VIC_UI_TARBALL} -C ui-nightly-run-bin --strip 1
     Should Be Equal As Integers  ${rc1}  0
     Should Be Equal As Integers  ${rc2}  0
+    Should Be Equal As Integers  ${rc3}  0
     # copy vic-ui-linux and plugin binaries to where test scripts will access them
     Run  cp -rf ui-nightly-run-bin/vic-ui-* ./
     Prepare Flex And H5 Plugins For Testing
 
 Prepare Flex And H5 Plugins For Testing
-    Run Keyword If  ${IS_NIGHTLY_TEST}  Run  cp -rf ui-nightly-run-bin/ui/* scripts/  ELSE  Build Flex And H5 Plugins
+    Run Keyword If  ${IS_NIGHTLY_TEST}  Run  cp -rf ui-nightly-run-bin/ci/ui/* scripts/  ELSE  Build Flex And H5 Plugins
+    # TODO: remove the following line and the keyword being called once the build number of vic-ui is in sync with vic repo
+    Run Keyword If  ${BUILD_VER_ISSUE_WORKAROUND}  Sync Vic Ui Version With Vic Repo
     # scp plugin binaries to the test file server
     Run  sshpass -p "${MACOS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r scripts/vsphere-client-serenity/*.zip ${MACOS_HOST_USER}@${MACOS_HOST_IP}:~/Documents/vc-plugin-store/public/vsphere-plugins/files/
     Run  sshpass -p "${MACOS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r scripts/plugin-packages/*.zip ${MACOS_HOST_USER}@${MACOS_HOST_IP}:~/Documents/vc-plugin-store/public/vsphere-plugins/files/
+
+Sync Vic Ui Version With Vic Repo
+    ${uname}=  Run  uname -v
+    ${is_macos}=  Run Keyword And Return Status  Should Contain  ${uname}  Darwin
+    ${vic_machine_binary}=  Run Keyword If  ${is_macos}  Set Variable  ./ui-nightly-run-bin/vic-machine-darwin  ELSE  Set Variable  ./ui-nightly-run-bin/vic-machine-linux
+    ${full_ver_string}=  Run  ${vic_machine_binary} version | awk '{print $3}' | sed -e 's/\-rc[[:digit:]]//g'
+    ${major_minor_patch}=  Run  echo ${full_ver_string} | awk -F- '{print $1}' | cut -c 2-
+    ${build_number}=  Run  echo ${full_ver_string} | awk -F- '{print $2}'
+
+    Run  sed 's/version=.*/version=\"${major_minor_patch}\.${build_number}\"/' ui-nightly-run-bin/ci/ui/plugin-manifest > scripts/plugin-manifest
+    Run  cp -rf ui-nightly-run-bin/ci/ui/plugin-packages/* scripts/plugin-packages/
+    Run  cp -rf ui-nightly-run-bin/ci/ui/vsphere-client-serenity/* scripts/vsphere-client-serenity/
+
+    ${tmp_build_number}=  Run  echo ${LATEST_VIC_UI_TARBALL} | grep -o "[[:digit:]]\\+"
+    Run  sed 's/vic" version="\.${tmp_build_number}"/vic" version="${major_minor_patch}\.${build_number}"/' scripts/plugin-packages/com.vmware.vic-v.${tmp_build_number}/plugin-package.xml > /tmp/plugin-bundle-h5c.xml
+    Run  sed 's/vic\.ui" version="\.${tmp_build_number}"/vic\.ui" version="${major_minor_patch}\.${build_number}"/' scripts/vsphere-client-serenity/com.vmware.vic.ui-v.${tmp_build_number}/plugin-package.xml > /tmp/plugin-bundle-flex.xml
+    Move File  /tmp/plugin-bundle-h5c.xml  scripts/plugin-packages/com.vmware.vic-v.${tmp_build_number}/plugin-package.xml
+    Move File  /tmp/plugin-bundle-flex.xml  scripts/vsphere-client-serenity/com.vmware.vic.ui-v.${tmp_build_number}/plugin-package.xml
+    Run  mv scripts/plugin-packages/com.vmware.vic-v.${tmp_build_number} scripts/plugin-packages/com.vmware.vic-v${major_minor_patch}.${build_number}
+    Run  mv scripts/vsphere-client-serenity/com.vmware.vic.ui-v.${tmp_build_number} scripts/vsphere-client-serenity/com.vmware.vic.ui-v${major_minor_patch}.${build_number}
+    Run  zip -9 -r scripts/plugin-packages/com.vmware.vic-v${major_minor_patch}.${build_number}.zip scripts/plugin-packages/com.vmware.vic-v${major_minor_patch}.${build_number}/*
+    Run  zip -9 -r scripts/vsphere-client-serenity/com.vmware.vic.ui-v${major_minor_patch}.${build_number}.zip scripts/vsphere-client-serenity/com.vmware.vic.ui-v${major_minor_patch}.${build_number}/*
 
 Build Flex And H5 Plugins
     # ensure build tools are accessible
@@ -106,7 +133,12 @@ Get Latest Vic Engine Binary
     ${input}=  Run  gsutil ls -l gs://vic-engine-builds/vic_* | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | cut -d '/' -f 4
     Set Suite Variable  ${buildNumber}  ${input}
     Set Suite Variable  ${LATEST_VIC_ENGINE_TARBALL}  ${input}
+    Log  Fetching the latest VIC UI tar ball...
+    ${input2}=  Run  gsutil ls -l gs://vic-ui-builds/vic_* | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | cut -d '/' -f 4
+    Set Suite Variable  ${LATEST_VIC_UI_TARBALL}  ${input2}
     ${results}=  Wait Until Keyword Succeeds  5x  15 sec  Download VIC Engine Tarball  https://storage.googleapis.com/vic-engine-builds/${input}  ${LATEST_VIC_ENGINE_TARBALL}
+    Should Be True  ${results}
+    ${results}=  Wait Until Keyword Succeeds  5x  15 sec  Download VIC Engine Tarball  https://storage.googleapis.com/vic-ui-builds/${input2}  ${LATEST_VIC_UI_TARBALL}
     Should Be True  ${results}
     Prepare VIC Engine Binaries
 

--- a/tests/manual-test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -280,25 +280,48 @@ Predeploy Vc And Esx
 
 Check Variables
     ${isset_SHELL}=  Run Keyword And Return Status  Environment Variable Should Be Set  SHELL
-    ${isset_NIMBUS_USER}=  Run Keyword And Return Status  Environment Variable Should Be Set  NIMBUS_USER
-    ${isset_NIMBUS_PASSWORD}=  Run Keyword And Return Status  Environment Variable Should Be Set  NIMBUS_PASSWORD
-    ${isset_NIMBUS_GW}=  Run Keyword And Return Status  Environment Variable Should Be Set  NIMBUS_GW
     ${isset_TEST_DATASTORE}=  Run Keyword And Return Status  Environment Variable Should Be Set  TEST_DATASTORE
     ${isset_TEST_RESOURCE}=  Run Keyword And Return Status  Environment Variable Should Be Set  TEST_RESOURCE
     ${isset_GOVC_INSECURE}=  Run Keyword And Return Status  Environment Variable Should Be Set  GOVC_INSECURE
     Log To Console  \nChecking environment variables
     Log To Console  SHELL ${isset_SHELL}
-    Log To Console  NIMBUS_USER ${isset_NIMBUS_USER}
-    Log To Console  NIMBUS_PASSWORD ${isset_NIMBUS_PASSWORD}
-    Log To Console  NIMBUS_GW ${isset_NIMBUS_GW}
     Log To Console  TEST_DATASTORE ${isset_TEST_DATASTORE}
     Log To Console  TEST_RESOURCE ${isset_TEST_RESOURCE}
     Log To Console  GOVC_INSECURE ${isset_GOVC_INSECURE}
     Log To Console  TEST_VSPHERE_VER %{TEST_VSPHERE_VER}
-    Should Be True  ${isset_SHELL} and ${isset_NIMBUS_USER} and ${isset_NIMBUS_GW} and ${isset_TEST_DATASTORE} and ${isset_TEST_RESOURCE} and ${isset_GOVC_INSECURE} and %{TEST_VSPHERE_VER}
+    Should Be True  ${isset_SHELL} and ${isset_TEST_DATASTORE} and ${isset_TEST_RESOURCE} and ${isset_GOVC_INSECURE} and %{TEST_VSPHERE_VER}
 
-Check Nimbus Machines
-    Check If Nimbus VMs Exist
+Get VMs Information
+    # remove testbed-information if it exists
+    ${ti_exists}=  Run Keyword And Return Status  OperatingSystem.Should Exist  testbed-information
+    Run Keyword If  ${ti_exists}  Remove File  testbed-information
+
+    # choose which selenium grid to use
+    Run Keyword If  '%{TEST_OS}' == 'Mac'  Set Environment Variable  SELENIUM_SERVER_IP  ${MACOS_HOST_IP}  ELSE  Set Environment Variable  SELENIUM_SERVER_IP  ${WINDOWS_HOST_IP}
+
+    ${esx_ip}=  Set Variable  ${BUILD_%{TEST_ESX_BUILD}_IP}
+    ${vcsa_ip}=  Set Variable  ${BUILD_%{TEST_VCSA_BUILD}_IP}
+
+    ${testbed-information-content}=  Catenate  SEPARATOR=\n
+    ...  TEST_VSPHERE_VER=%{TEST_VSPHERE_VER}
+    ...  SELENIUM_SERVER_IP=%{SELENIUM_SERVER_IP}
+    ...  TEST_ESX_NAME=esx-%{TEST_ESX_BUILD}
+    ...  ESX_HOST_IP=${esx_ip}
+    ...  ESX_HOST_PASSWORD=ca*hc0w
+    ...  TEST_VC_NAME=vc-%{TEST_VCSA_BUILD}
+    ...  TEST_VC_IP=${vcsa_ip}
+    ...  TEST_URL_ARRAY=${vcsa_ip}
+    ...  TEST_USERNAME=Administrator@vsphere.local
+    ...  TEST_PASSWORD=Admin\!23
+    ...  TEST_DATASTORE=datastore1
+    ...  EXTERNAL_NETWORK=vm-network
+    ...  TEST_TIMEOUT=30m
+    ...  GOVC_INSECURE=1
+    ...  GOVC_USERNAME=Administrator@vsphere.local
+    ...  GOVC_PASSWORD=Admin\!23
+    ...  GOVC_URL=${vcsa_ip}\n
+
+    Create File  testbed-information  ${testbed-information-content}
 
 Deploy VCH
     Load Nimbus Testbed Env

--- a/tests/manual-test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -280,16 +280,12 @@ Predeploy Vc And Esx
 
 Check Variables
     ${isset_SHELL}=  Run Keyword And Return Status  Environment Variable Should Be Set  SHELL
-    ${isset_TEST_DATASTORE}=  Run Keyword And Return Status  Environment Variable Should Be Set  TEST_DATASTORE
-    ${isset_TEST_RESOURCE}=  Run Keyword And Return Status  Environment Variable Should Be Set  TEST_RESOURCE
     ${isset_GOVC_INSECURE}=  Run Keyword And Return Status  Environment Variable Should Be Set  GOVC_INSECURE
     Log To Console  \nChecking environment variables
     Log To Console  SHELL ${isset_SHELL}
-    Log To Console  TEST_DATASTORE ${isset_TEST_DATASTORE}
-    Log To Console  TEST_RESOURCE ${isset_TEST_RESOURCE}
     Log To Console  GOVC_INSECURE ${isset_GOVC_INSECURE}
     Log To Console  TEST_VSPHERE_VER %{TEST_VSPHERE_VER}
-    Should Be True  ${isset_SHELL} and ${isset_TEST_DATASTORE} and ${isset_TEST_RESOURCE} and ${isset_GOVC_INSECURE} and %{TEST_VSPHERE_VER}
+    Should Be True  ${isset_SHELL} and ${isset_GOVC_INSECURE} and %{TEST_VSPHERE_VER}
 
 Get VMs Information
     # remove testbed-information if it exists
@@ -313,7 +309,7 @@ Get VMs Information
     ...  TEST_URL_ARRAY=${vcsa_ip}
     ...  TEST_USERNAME=Administrator@vsphere.local
     ...  TEST_PASSWORD=Admin\!23
-    ...  TEST_DATASTORE=datastore1
+    ...  TEST_DATASTORE=${TEST_DATASTORE}
     ...  EXTERNAL_NETWORK=vm-network
     ...  TEST_TIMEOUT=30m
     ...  GOVC_INSECURE=1
@@ -335,7 +331,7 @@ Deploy VCH
     Append To File  testbed-information  TEST_OS=%{TEST_OS}\n
     Append To File  testbed-information  DRONE_BUILD_NUMBER=%{DRONE_BUILD_NUMBER}\n
     Append To File  testbed-information  BRIDGE_NETWORK=%{BRIDGE_NETWORK}\n
-    Append To File  testbed-information  TEST_DATACENTER=%{TEST_DATACENTER}\n
+    Append To File  testbed-information  TEST_DATACENTER=${TEST_DATACENTER}\n
     Append To File  testbed-information  TEST_URL=%{TEST_URL}\n
     Append To File  testbed-information  VCH_VM_NAME=%{VCH-NAME}\n
     Append To File  testbed-information  VCH-IP=%{VCH-IP}\n

--- a/tests/manual-test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/vicui-common.robot
@@ -25,7 +25,6 @@ ${BUILD_3620759_IP}                   10.25.200.237
 ${BUILD_3634791_IP}                   10.25.200.245
 ${BUILD_5310538_IP}                   10.25.200.231
 ${BUILD_5318154_IP}                   10.25.200.243
-${SECRETS_FILE}                       test.secrets
 ${TEST_DATASTORE}                     datastore1
 ${TEST_DATACENTER}                    /Datacenter
 ${TEST_RESOURCE}                      /Datacenter/host/Cluster/Resources
@@ -203,7 +202,6 @@ Cleanup MacOS Testbed
     ...  /Users/browseruser/Desktop/vic/tests/manual-test-cases/Group18-VIC-UI/testbed-information
     ...  /Users/browseruser/Desktop/vic/tests/manual-test-cases/Group18-VIC-UI/VCH-0*
     ...  /Users/browseruser/Desktop/vic/tests/manual-test-cases/Group18-VIC-UI/18-*.zip
-    ...  /Users/browseruser/Desktop/vic/test.secrets
     ...  /tmp/vic-ui-e2e-scratch
 
     ${output}=  Run  rm -rvf ${files_to_remove} 2>&1
@@ -214,7 +212,6 @@ Cleanup Windows Testbed
     ...  ~/vic/tests/manual-test-cases/Group18-VIC-UI/testbed-information
     ...  ~/vic/tests/manual-test-cases/Group18-VIC-UI/VCH-0*
     ...  ~/vic/tests/manual-test-cases/Group18-VIC-UI/18-*.zip
-    ...  ~/vic/test.secrets
     ...  /tmp/vic-ui-e2e-scratch
 
     ${output}=  Run  rm -rf ${files_to_remove} 2>&1

--- a/tests/manual-test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/vicui-common.robot
@@ -26,6 +26,13 @@ ${BUILD_3634791_IP}                   10.25.200.245
 ${BUILD_5310538_IP}                   10.25.200.231
 ${BUILD_5318154_IP}                   10.25.200.243
 ${SECRETS_FILE}                       test.secrets
+${TEST_DATASTORE}                     datastore1
+${TEST_DATACENTER}                    /Datacenter
+${TEST_RESOURCE}                      /Datacenter/host/Cluster/Resources
+${MACOS_HOST_USER}                    browseruser
+${MACOS_HOST_PASSWORD}                ca*hc0w
+${WINDOWS_HOST_USER}                  IEUser
+${WINDOWS_HOST_PASSWORD}              Passw0rd!
 ${vic_macmini_fileserver_url}         https://10.20.121.192:3443/vsphere-plugins/
 ${vic_macmini_fileserver_thumbprint}  BE:64:39:8B:BD:98:47:4D:E8:3B:2F:20:A5:21:8B:86:5F:AD:79:CE
 ${GCP_DOWNLOAD_PATH}                  https://storage.googleapis.com/vic-engine-builds/
@@ -53,17 +60,6 @@ Load Nimbus Testbed Env
     \  Set Suite Variable  \$@{kv}[0]  @{kv}[1]
     Set Suite Variable  ${TEST_VC_USERNAME}  %{TEST_USERNAME}
     Set Suite Variable  ${TEST_VC_PASSWORD}  %{TEST_PASSWORD}
-
-Load Secrets
-    [Arguments]  ${secrets}=${SECRETS_FILE}
-    OperatingSystem.File Should Exist  ${secrets}
-    ${envs}=  OperatingSystem.Get File  ${secrets}
-    @{envs}=  Split To Lines  ${envs}
-    :FOR  ${item}  IN  @{envs}
-    \  @{kv}=  Split String  ${item}  =
-    \  ${stripped}=  Replace String  @{kv}[1]  "  ${EMPTY}
-    \  Set Environment Variable  @{kv}[0]  ${stripped}
-    \  Set Suite Variable  \$@{kv}[0]  @{kv}[1]
 
 Install VIC Appliance For VIC UI
     [Arguments]  ${vic-machine}=ui-nightly-run-bin/vic-machine-linux  ${appliance-iso}=ui-nightly-run-bin/appliance.iso  ${bootstrap-iso}=ui-nightly-run-bin/bootstrap.iso  ${certs}=${true}  ${vol}=default
@@ -165,7 +161,7 @@ Cleanup Installer Environment
 Delete VIC Machine
     [Tags]  secret
     [Arguments]  ${vch-name}  ${vic-machine}=ui-nightly-run-bin/vic-machine-linux
-    ${rc}  ${output}=  Run And Return Rc And Output  ${vic-machine} delete --name=${vch-name} --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
+    ${rc}  ${output}=  Run And Return Rc And Output  ${vic-machine} delete --name=${vch-name} --target=%{TEST_URL}${TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=${TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
     [Return]  ${rc}  ${output}
 
 Uninstall VCH

--- a/tests/manual-test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/vicui-common.robot
@@ -21,6 +21,10 @@ Library  VicUiInstallPexpectLibrary.py
 ${MACOS_HOST_IP}                      10.20.121.192
 ${UBUNTU_HOST_IP}                     10.20.121.145
 ${WINDOWS_HOST_IP}                    10.25.200.225
+${BUILD_3620759_IP}                   10.25.200.237
+${BUILD_3634791_IP}                   10.25.200.245
+${BUILD_5310538_IP}                   10.25.200.231
+${BUILD_5318154_IP}                   10.25.200.243
 ${SECRETS_FILE}                       test.secrets
 ${vic_macmini_fileserver_url}         https://10.20.121.192:3443/vsphere-plugins/
 ${vic_macmini_fileserver_thumbprint}  BE:64:39:8B:BD:98:47:4D:E8:3B:2F:20:A5:21:8B:86:5F:AD:79:CE


### PR DESCRIPTION
This PR updates the integration tests codebase such that all references to the `vic` repo are  properly replaced with `vic-ui`. Also, once merged into master, the integration tests will no longer rely on Nimbus to create testbeds. Instead, an in-house Dell server would be used in its place on which vSphere 6.0 and 6.5 instances are already deployed.
 
Fixes vic#6548.