### PR TITLE
Fix undefined datastore console error

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/storage-capacity/storage-capacity.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/storage-capacity/storage-capacity.component.ts
@@ -36,7 +36,9 @@ export class StorageCapacityComponent implements OnInit {
   public datastoresLoading = true;
   private _isSetup = false;
   @Input() set resourceObjRef(value) {
-    this.loadDatastore(value);
+    if (typeof value !== 'undefined') {
+      this.loadDatastore(value);
+    }
   }
 
   constructor(


### PR DESCRIPTION
This PR fixes a console error generated from storage-capacity when trying to obtain datastores from an undefined (not yet selected) compute resource.