### PR TITLE
Make VchLogView use lookup and clone ticket endpoints

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.service.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.service.ts
@@ -13,22 +13,25 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-import { Injectable } from '@angular/core';
-import { Http, URLSearchParams } from '@angular/http';
-import { Observable } from 'rxjs/Observable';
+
 import 'rxjs/add/observable/timer';
 import 'rxjs/add/observable/zip';
 import 'rxjs/add/operator/mergeAll';
 import 'rxjs/add/operator/mergeMap';
+
 import {
-  VIC_APPLIANCE_PORT,
-  VIC_APPLIANCES_LOOKUP_URL,
   CHECK_RP_UNIQUENESS_URL,
-  GET_CLONE_TICKET_URL,
   CPU_MIN_LIMIT_MHZ,
-  MEMORY_MIN_LIMIT_MB
+  GET_CLONE_TICKET_URL,
+  MEMORY_MIN_LIMIT_MB,
+  VIC_APPLIANCES_LOOKUP_URL,
+  VIC_APPLIANCE_PORT
 } from '../shared/constants';
+import { Http, URLSearchParams } from '@angular/http';
+
 import { GlobalsService } from '../shared';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
 import { byteToLegibleUnit } from '../shared/utils/filesize';
 
 @Injectable()
@@ -81,9 +84,9 @@ export class CreateVchWizardService {
      */
     acquireCloneTicket(): Observable<string> {
       return this.http.get(GET_CLONE_TICKET_URL)
-        .catch(e => Observable.throw(e));
+        .catch(e => Observable.throw(e))
+        .map(response => response.text());
     }
-
 
     /**
      * Get user id

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/general/general.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/general/general.component.spec.ts
@@ -54,7 +54,7 @@ describe('VchCreationWizardGeneralComponent', () => {
                 return Observable.of(true);
               }
             },
-            getVicApplianceIp: (): Observable<string> => {
+            getVicApplianceIp(): Observable<string> {
               return Observable.of('10.20.250.255');
             }
           }

--- a/h5c/vic/src/vic-webapp/src/app/services/extended-usersession.service.ts
+++ b/h5c/vic/src/vic-webapp/src/app/services/extended-usersession.service.ts
@@ -1,7 +1,3 @@
-import { Globals, GlobalsService } from '../shared';
-
-import { Http } from '@angular/http';
-import { IExtendedServerInfo } from './extended-serverinfo.interface';
 /*
  Copyright 2017 VMware, Inc. All Rights Reserved.
 
@@ -17,6 +13,11 @@ import { IExtendedServerInfo } from './extended-serverinfo.interface';
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+import { Globals, GlobalsService } from '../shared';
+
+import { Http } from '@angular/http';
+import { IExtendedServerInfo } from './extended-serverinfo.interface';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 

--- a/h5c/vic/src/vic-webapp/src/app/vch-view/vch-log-view/vch-log-view.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/vch-view/vch-log-view/vch-log-view.component.spec.ts
@@ -14,26 +14,31 @@
  limitations under the License.
 */
 
-import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import {
-  Http,
+  BaseRequestOptions,
   ConnectionBackend,
+  Http,
+  RequestOptions,
   Response,
   ResponseOptions,
-  RequestOptions,
-  BaseRequestOptions,
 } from '@angular/http';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { Globals, GlobalsService } from '../../shared';
+import { MockBackend, MockConnection } from '@angular/http/testing';
+
 import { By } from '@angular/platform-browser';
+import { ClarityModule } from 'clarity-angular';
+import { CreateVchWizardService } from '../../create-vch-wizard/create-vch-wizard.service';
+import { ExtendedUserSessionService } from '../../services/extended-usersession.service';
+import { IExtendedServerInfo } from '../../services/extended-serverinfo.interface';
+import { Observable } from 'rxjs/Observable';
+import { ReactiveFormsModule } from '@angular/forms';
+import { VchVmResponse } from '../../interfaces/vm.interface';
+import { VicVchLogViewComponent } from './vch-log-view.component';
+import { VirtualContainerHost } from '../vch.model';
 import {
   getVchResponseStub
 } from '../../services/mocks/vch.response';
-import { VicVchLogViewComponent } from './vch-log-view.component';
-import { ClarityModule } from 'clarity-angular';
-import { ReactiveFormsModule } from '@angular/forms';
-import { MockBackend, MockConnection } from '@angular/http/testing';
-import { Globals, GlobalsService } from '../../shared';
-import { VirtualContainerHost } from '../vch.model';
-import { VchVmResponse } from '../../interfaces/vm.interface';
 
 describe('VicVchLogViewComponent', () => {
   let fixture: ComponentFixture<VicVchLogViewComponent>;
@@ -59,6 +64,31 @@ describe('VicVchLogViewComponent', () => {
                 serversInfo: [{ thumbprint: '00' }]
               })
             })
+          }
+        },
+        {
+          provide: CreateVchWizardService,
+          useValue: {
+            getVicApplianceIp(): Observable<string> {
+              return Observable.of('10.20.250.255');
+            },
+            acquireCloneTicket(): Observable<string> {
+              return Observable.of('ticket');
+            }
+          }
+        },
+        {
+          provide: ExtendedUserSessionService,
+          useValue: {
+            getVcenterServersInfo(): IExtendedServerInfo[] {
+              return [{
+                name: '10.20.30.10',
+                serverGuid: 'aa-dd-cc-00-ff',
+                sessionCookie: 'nomnom',
+                thumbprint: '01:AB:CD:EF',
+                version: '1'
+              }];
+            }
           }
         }
       ],

--- a/h5c/vic/src/vic-webapp/src/app/vch-view/vch-log-view/vch-log-view.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/vch-view/vch-log-view/vch-log-view.component.ts
@@ -54,7 +54,6 @@ export class VicVchLogViewComponent implements OnInit {
       this.createWzService.getVicApplianceIp(),
       this.createWzService.acquireCloneTicket()
     ).catch(err => {
-      console.error(err);
       return Observable.throw(err);
     }).subscribe(([serviceHost, cloneTicket]) => {
       const vchId = this.vch.id.split(':')[3];
@@ -65,7 +64,6 @@ export class VicVchLogViewComponent implements OnInit {
       const url =
         `https://${serviceHost}:${servicePort}/container/target/${targetHostname}/vch/${vchId}/log?thumbprint=${targetThumbprint}`;
 
-      console.log(url, cloneTicket);
       const headers  = new Headers({
         'Content-Type': 'application/json',
         'X-VMWARE-TICKET': cloneTicket
@@ -75,11 +73,9 @@ export class VicVchLogViewComponent implements OnInit {
       this.http.get(url, options)
         .map(response => response.json())
         .subscribe(response => {
-          console.log('success response:', response);
           this.log = response;
           this.loading = false;
         }, error => {
-          console.error('error response:', error);
           this.log = error.message || 'Error loading VCH log!';
           this.loading = false;
         });

--- a/h5c/vic/src/vic-webapp/src/app/vch-view/vch-log-view/vch-log-view.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/vch-view/vch-log-view/vch-log-view.component.ts
@@ -50,15 +50,13 @@ export class VicVchLogViewComponent implements OnInit {
 
   ngOnInit() {
     this.loading = true;
-    Observable.zip(
+    Observable.combineLatest(
       this.createWzService.getVicApplianceIp(),
       this.createWzService.acquireCloneTicket()
     ).catch(err => {
       console.error(err);
       return Observable.throw(err);
-    }).subscribe(arr => {
-      const serviceHost = arr[0];
-      const cloneTicket = arr[1];
+    }).subscribe(([serviceHost, cloneTicket]) => {
       const vchId = this.vch.id.split(':')[3];
       const servicePort = VIC_APPLIANCE_PORT;
       const targetHost = this.extSessionService.getVcenterServersInfo()[0];

--- a/h5c/vic/src/vic-webapp/src/app/vch-view/vch-log-view/vch-log-view.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/vch-view/vch-log-view/vch-log-view.component.ts
@@ -16,9 +16,14 @@
 
 import { Component, Input, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { VirtualContainerHost } from '../vch.model';
-import { Http, Headers, RequestOptions } from '@angular/http';
+import { Headers, Http, RequestOptions } from '@angular/http';
+
+import { CreateVchWizardService } from '../../create-vch-wizard/create-vch-wizard.service';
+import { ExtendedUserSessionService } from '../../services/extended-usersession.service';
 import { GlobalsService } from '../../shared';
+import { Observable } from 'rxjs/Observable';
+import { VIC_APPLIANCE_PORT } from '../../shared/constants/create-vch-wizard';
+import { VirtualContainerHost } from '../vch.model';
 
 @Component({
   selector: 'vic-vch-log-view',
@@ -34,7 +39,9 @@ export class VicVchLogViewComponent implements OnInit {
   constructor(
     private formBuilder: FormBuilder,
     private globalsService: GlobalsService,
-    private http: Http
+    private http: Http,
+    private createWzService: CreateVchWizardService,
+    private extSessionService: ExtendedUserSessionService
   ) {
     this.form = formBuilder.group({
       enableSSH: false
@@ -42,33 +49,42 @@ export class VicVchLogViewComponent implements OnInit {
   }
 
   ngOnInit() {
-    const vchId = this.vch.id.split(':')[3];
-    const serviceHost = '10.160.131.87';
-    const servicePort = '31337';
-    const targetHost = '10.192.93.240';
-    const targetThumbprint = this.globalsService.getWebPlatform().getUserSession()['serversInfo'][0]['thumbprint'];
-
-    // TODO: replace api endpoint IP with OVA IP and target IP with current target VC IP
-    const url = `https://${serviceHost}:${servicePort}/container/target/${targetHost}/vch/${vchId}/log?thumbprint=${targetThumbprint}`;
-
-    const headers  = new Headers({
-      'Content-Type': 'application/json',
-      'Authorization': 'Basic YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2FsOkFkbWluITIz'
-    });
-
-    const options  = new RequestOptions({ headers: headers });
-
     this.loading = true;
-    this.http.get(url, options)
-      .map(response => response.json())
-      .subscribe(response => {
-        console.log('success response:', response);
-        this.log = response;
-        this.loading = false;
-      }, error => {
-        console.error('error response:', error);
-        this.log = error.message || 'Error loading VCH log!';
-        this.loading = false;
+    Observable.zip(
+      this.createWzService.getVicApplianceIp(),
+      this.createWzService.acquireCloneTicket()
+    ).catch(err => {
+      console.error(err);
+      return Observable.throw(err);
+    }).subscribe(arr => {
+      const serviceHost = arr[0];
+      const cloneTicket = arr[1];
+      const vchId = this.vch.id.split(':')[3];
+      const servicePort = VIC_APPLIANCE_PORT;
+      const targetHost = this.extSessionService.getVcenterServersInfo()[0];
+      const targetHostname = targetHost.name;
+      const targetThumbprint = targetHost.thumbprint;
+      const url =
+        `https://${serviceHost}:${servicePort}/container/target/${targetHostname}/vch/${vchId}/log?thumbprint=${targetThumbprint}`;
+
+      console.log(url, cloneTicket);
+      const headers  = new Headers({
+        'Content-Type': 'application/json',
+        'X-VMWARE-TICKET': cloneTicket
       });
+
+      const options  = new RequestOptions({ headers: headers });
+      this.http.get(url, options)
+        .map(response => response.json())
+        .subscribe(response => {
+          console.log('success response:', response);
+          this.log = response;
+          this.loading = false;
+        }, error => {
+          console.error('error response:', error);
+          this.log = error.message || 'Error loading VCH log!';
+          this.loading = false;
+        });
+    });
   }
 }

--- a/h5c/vic/src/vic-webapp/src/app/vch-view/vch-view.module.ts
+++ b/h5c/vic/src/vic-webapp/src/app/vch-view/vch-view.module.ts
@@ -13,15 +13,17 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { RouterModule, Routes } from '@angular/router';
-import { ClarityModule } from 'clarity-angular';
-import { VicVchViewComponent } from './vch-view.component';
-import { VicVchLogViewComponent } from './vch-log-view/vch-log-view.component';
-import { VicVmViewService } from '../services/vm-view.service';
-import { ExtendedUserSessionService } from '../services/extended-usersession.service';
+import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+
+import { ClarityModule } from 'clarity-angular';
+import { CommonModule } from '@angular/common';
+import { CreateVchWizardService } from '../create-vch-wizard/create-vch-wizard.service';
+import { ExtendedUserSessionService } from '../services/extended-usersession.service';
+import { VicVchLogViewComponent } from './vch-log-view/vch-log-view.component';
+import { VicVchViewComponent } from './vch-view.component';
+import { VicVmViewService } from '../services/vm-view.service';
 
 const routes: Routes = [
     { path: '', component: VicVchViewComponent },
@@ -43,7 +45,8 @@ const routes: Routes = [
     ],
     providers: [
         VicVmViewService,
-        ExtendedUserSessionService
+        ExtendedUserSessionService,
+        CreateVchWizardService
     ],
     exports: [
       VicVchViewComponent


### PR DESCRIPTION
This PR updates @cristianfalcone's VCH Log component to use the VIC appliance lookup and vSphere session clone ticket endpoints such that the UI would talk to the correct API endpoint.