### PR TITLE
Fix a failing test case in H5C plugin E2E tests

### DIFF
--- a/h5c/vic-uia/src/main/java/com/vmware/vsphere/client/automation/test/vch/VchPortletDisplaysInfoWhileOnTest.java
+++ b/h5c/vic-uia/src/main/java/com/vmware/vsphere/client/automation/test/vch/VchPortletDisplaysInfoWhileOnTest.java
@@ -1,8 +1,8 @@
 package com.vmware.vsphere.client.automation.test.vch;
 
 import com.vmware.automation.core.annotation.RequiresTestbed;
-import com.vmware.automation.core.testbed.Testbed;
 import com.vmware.automation.core.testbed.ITestbedRequester.TestbedAllocation;
+import com.vmware.automation.core.testbed.Testbed;
 import com.vmware.automation.core.workflow.IWorkflowSpec;
 import com.vmware.automation.core.workflow.StepComposition;
 import com.vmware.automation.core.workflow.WorkflowStep;
@@ -19,8 +19,6 @@ import com.vmware.vsphere.client.automation.step.common.MaximizeWindowStep;
 import com.vmware.vsphere.client.automation.step.common.VerifyPortletVisibilityStep;
 import com.vmware.vsphere.client.automation.step.common.VicCommon;
 import com.vmware.vsphere.client.automation.step.srv.vm.SetVmPowerStateByApiStep;
-import com.vmware.vsphere.client.automation.step.ui.ClarityAlertClickYesStep;
-import com.vmware.vsphere.client.automation.step.ui.ConfirmClarityDialogStep;
 import com.vmware.vsphere.client.automation.step.ui.InvokeActionMenuItemStep;
 import com.vmware.vsphere.client.automation.step.ui.VerifyRecentTaskStep;
 import com.vmware.vsphere.client.automation.step.vch.VerifyVchPortletContentStep;
@@ -37,61 +35,60 @@ import com.vmware.vsphere.client.automation.testbed.VicTestbed;
  * 4. Verify portlet 'Virtual Container Host' exists
  * 5. Verify portlet 'Virtual Container Host' displays a correct value for Docker API endpoint
  * 6. Verify portlet 'Virtual Container Host' displays a correct value for VCH Admin portal
-*/
+ */
 public class VchPortletDisplaysInfoWhileOnTest extends WebClientTest {
-	@RequiresTestbed(clazz = SingleNgcTestbed.class, allocation = TestbedAllocation.SHARED)
-	private Testbed _singleNgcTestbed;
+    @RequiresTestbed(clazz = SingleNgcTestbed.class, allocation = TestbedAllocation.SHARED)
+    private Testbed _singleNgcTestbed;
 
-	@RequiresTestbed(clazz = HostTestbed.class)
-	private HostTestbed _hostTestbed;
+    @RequiresTestbed(clazz = HostTestbed.class)
+    private HostTestbed _hostTestbed;
 
-	@RequiresTestbed(clazz = VicTestbed.class)
-	private VicTestbed _vicTestbed;
-	
-	private SingleValueSpec<PowerState> _poweredOnSpec = new SingleValueSpec<PowerState>(PowerState.poweredOn);
-	private VmSpec _vchVmSpec;
-	private PortletSpec _vchPortletSpec;
-	private RecentTaskFilterSpec _powerOnVMTaskSpec;
+    @RequiresTestbed(clazz = VicTestbed.class)
+    private VicTestbed _vicTestbed;
 
-	@Override
-	public String getDescription() {
-		return String.format("Checks if VCH portlet displays valid values while VM is on");
-	}
-	
-	@Override
-	protected void addSpecsToWorkflow(IWorkflowSpec specsToAdd) {
-		super.addSpecsToWorkflow(specsToAdd);
-		
-		_vchVmSpec = _vicTestbed.vchVmSpec;
-		_vchPortletSpec = VicCommon.buildPortletSpec(VicCommon.VCH_PORTLET_TITLE);
+    private SingleValueSpec<PowerState> _poweredOnSpec = new SingleValueSpec<PowerState>(PowerState.poweredOn);
+    private VmSpec _vchVmSpec;
+    private PortletSpec _vchPortletSpec;
+    private RecentTaskFilterSpec _powerOnVMTaskSpec;
 
-		_powerOnVMTaskSpec = new RecentTaskFilterSpec(
-				L10NVmConst.Task.POWER_ON_VM,
-				_vchVmSpec.getName(),
-				RecentTaskStatus.COMPLETED
-		);
-		
-		specsToAdd.addSpec(_vchVmSpec, _vchPortletSpec, _powerOnVMTaskSpec, _poweredOnSpec);
-	}
-	
-	@Override
-	protected void addSetupSteps(StepComposition<WorkflowStep> steps) {
-		steps.add(new SetVmPowerStateByApiStep(PowerState.poweredOff), _vchVmSpec);
-		steps.add(new MaximizeWindowStep());
-	}
+    @Override
+    public String getDescription() {
+        return String.format("Checks if VCH portlet displays valid values while VM is on");
+    }
 
-	@Override
-	protected void addTestSteps(StepComposition<WorkflowStep> steps) {
-		steps
-			.add(new ObjectNavigator(L10NVmConst.Navigator.VC_INVENTORY_LISTS))
-			.add(new ObjectNavigator(L10NVmConst.Navigator.VMS))
-			.add(new ObjectNavigator(_vicTestbed.vchVmSpec.getName()))
-			.add(new TabNavigator(L10NVmConst.Tab.SUMMARY))
-			.add(new InvokeActionMenuItemStep(L10NVmConst.Action.POWER, L10NVmConst.Action.POWER_ON))
-			.add(new ClarityAlertClickYesStep())
-			.add(new VerifyRecentTaskStep())
-			.add(new VerifyPortletVisibilityStep(), _vchVmSpec)
-			.add(new VerifyVchPortletContentStep(), _poweredOnSpec);
-	}
+    @Override
+    protected void addSpecsToWorkflow(IWorkflowSpec specsToAdd) {
+        super.addSpecsToWorkflow(specsToAdd);
+
+        _vchVmSpec = _vicTestbed.vchVmSpec;
+        _vchPortletSpec = VicCommon.buildPortletSpec(VicCommon.VCH_PORTLET_TITLE);
+
+        _powerOnVMTaskSpec = new RecentTaskFilterSpec(
+                L10NVmConst.Task.POWER_ON_VM,
+                _vchVmSpec.getName(),
+                RecentTaskStatus.COMPLETED
+                );
+
+        specsToAdd.addSpec(_vchVmSpec, _vchPortletSpec, _powerOnVMTaskSpec, _poweredOnSpec);
+    }
+
+    @Override
+    protected void addSetupSteps(StepComposition<WorkflowStep> steps) {
+        steps.add(new SetVmPowerStateByApiStep(PowerState.poweredOff), _vchVmSpec);
+        steps.add(new MaximizeWindowStep());
+    }
+
+    @Override
+    protected void addTestSteps(StepComposition<WorkflowStep> steps) {
+        steps
+        .add(new ObjectNavigator(L10NVmConst.Navigator.VC_INVENTORY_LISTS))
+        .add(new ObjectNavigator(L10NVmConst.Navigator.VMS))
+        .add(new ObjectNavigator(_vicTestbed.vchVmSpec.getName()))
+        .add(new TabNavigator(L10NVmConst.Tab.SUMMARY))
+        .add(new InvokeActionMenuItemStep(L10NVmConst.Action.POWER, L10NVmConst.Action.POWER_ON))
+        .add(new VerifyRecentTaskStep())
+        .add(new VerifyPortletVisibilityStep(), _vchVmSpec)
+        .add(new VerifyVchPortletContentStep(), _poweredOnSpec);
+    }
 
 }


### PR DESCRIPTION
Since a VCH is created under a ResourcePool instead of a vApp, an E2E test case has been failing where the H5C UI no longer asks the user, in a Clarity dialog, if s/he wants to turn on the VCH VM when it's off. This PR addresses the issue.