### PR TITLE
Catch when provided VC hostname/ip is incorrect

### DIFF
--- a/scripts/vCenterForWindows/install.bat
+++ b/scripts/vCenterForWindows/install.bat
@@ -128,7 +128,6 @@ IF %ERRORLEVEL% EQU 0 (
 )
 
 REM in case VIC_MACHINE_THUMBPRINT environment variable is set, use it
-TYPE scratch.tmp | findstr -c:"com.vmware.vic.noop is not registered" > NUL
 IF NOT "%VIC_MACHINE_THUMBPRINT%" == "" (
     SETLOCAL ENABLEDELAYEDEXPANSION
     SET vc_thumbprint=%VIC_MACHINE_THUMBPRINT%
@@ -136,6 +135,16 @@ IF NOT "%VIC_MACHINE_THUMBPRINT%" == "" (
     ECHO.
     ECHO SHA-1 key fingerprint of host '%target_vcenter_ip%' is '!vc_thumbprint!'
     GOTO validate_vc_thumbprint
+)
+
+TYPE scratch.tmp | findstr -i -c:"no such host" > NUL
+IF %ERRORLEVEL% EQU 0 (
+    TYPE scratch.tmp
+    ECHO -------------------------------------------------------------
+    ECHO Error! Could not register the plugin with vCenter Server. Please see the message above
+    DEL scratch*.tmp 2>NUL
+    ENDLOCAL
+    EXIT /b 1
 )
 
 REM either certificate is trusted or %VIC_MACHINE_THUMBPRINT% is set already

--- a/scripts/vCenterForWindows/uninstall.bat
+++ b/scripts/vCenterForWindows/uninstall.bat
@@ -110,7 +110,6 @@ IF %ERRORLEVEL% EQU 0 (
 )
 
 REM in case VIC_MACHINE_THUMBPRINT environment variable is set, use it
-TYPE scratch.tmp | findstr -c:"com.vmware.vic.noop is not registered" > NUL
 IF NOT "%VIC_MACHINE_THUMBPRINT%" == "" (
     SETLOCAL ENABLEDELAYEDEXPANSION
     SET vc_thumbprint=%VIC_MACHINE_THUMBPRINT%
@@ -118,6 +117,16 @@ IF NOT "%VIC_MACHINE_THUMBPRINT%" == "" (
     ECHO.
     ECHO SHA-1 key fingerprint of host '%target_vcenter_ip%' is '!vc_thumbprint!'
     GOTO validate_vc_thumbprint
+)
+
+TYPE scratch.tmp | findstr -i -c:"no such host" > NUL
+IF %ERRORLEVEL% EQU 0 (
+    TYPE scratch.tmp
+    ECHO -------------------------------------------------------------
+    ECHO Error! Could not uninstall the plugin from vCenter Server. Please see the message above
+    DEL scratch*.tmp 2>NUL
+    ENDLOCAL
+    EXIT /b 1
 )
 
 REM either certificate is trusted or %VIC_MACHINE_THUMBPRINT% is set already
@@ -163,7 +172,7 @@ GOTO end
 DEL scratch*.tmp 2>NUL
 IF %uninstall_successful% NEQ 1 (
     ECHO -------------------------------------------------------------
-    ECHO Error! Could not register plugin with vCenter Server. Please see the message above
+    ECHO Error! Could not uninstall the plugin from vCenter Server. Please see the message above
     ENDLOCAL
     EXIT /b 1
 )

--- a/scripts/vCenterForWindows/upgrade.bat
+++ b/scripts/vCenterForWindows/upgrade.bat
@@ -123,7 +123,6 @@ IF %ERRORLEVEL% EQU 0 (
 )
 
 REM in case VIC_MACHINE_THUMBPRINT environment variable is set, use it
-TYPE scratch.tmp | findstr -c:"com.vmware.vic.noop is not registered" > NUL
 IF NOT "%VIC_MACHINE_THUMBPRINT%" == "" (
     SETLOCAL ENABLEDELAYEDEXPANSION
     SET vc_thumbprint=%VIC_MACHINE_THUMBPRINT%
@@ -131,6 +130,16 @@ IF NOT "%VIC_MACHINE_THUMBPRINT%" == "" (
     ECHO.
     ECHO SHA-1 key fingerprint of host '%target_vcenter_ip%' is '!vc_thumbprint!'
     GOTO validate_vc_thumbprint
+)
+
+TYPE scratch.tmp | findstr -i -c:"no such host" > NUL
+IF %ERRORLEVEL% EQU 0 (
+    TYPE scratch.tmp
+    ECHO -------------------------------------------------------------
+    ECHO Error! Could not register the plugin with vCenter Server. Please see the message above
+    DEL scratch*.tmp 2>NUL
+    ENDLOCAL
+    EXIT /b 1
 )
 
 :validate_vc_thumbprint


### PR DESCRIPTION
This PR addresses nightly failures on uninstaller and upgrader scripts for WIndows where trying to run the script against a non-existent host was not properly handled. It should throw an error that it could not connect to the provided host but it would go ahead and ask the user to accept the thumbprint comes out empty.