### PR TITLE
Add skip tests feature to integration tests kickoff script

### DIFF
--- a/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -233,7 +233,7 @@ Run Script Test With Config
     Log To Console  VCSA build: ${vc_build}
     Log To Console  Operating System: ${os}
     Run Keyword If  ${is_skipped}  Log To Console  Skipped...
-    Run Keyword If  ${is_skipped}  Set To Dictionary  ${results_dict}  ${dict_key}  \[SKIPPED\] ${title} / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os}
+    Run Keyword If  ${is_skipped}  Set To Dictionary  ${results_dict}  ${dict_key}  \[ SKIPPED \]\t${title} / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os}
     Return From Keyword If  ${is_skipped}
     Get Testbed Information
     Set Environment Variable  VCH-NAME  %{VCH_VM_NAME}
@@ -255,8 +255,8 @@ Run Script Test With Config
 
     # set pass/fail based on return code
     Run Keyword Unless  ${results.rc} == 0  Set Global Variable  ${ALL_TESTS_PASSED}  ${FALSE}
-    ${pf}=  Run Keyword If  ${results.rc} == 0  Set Variable  \[PASSED\]  ELSE  Set Variable  \[FAILED\]
-    ${pf_string}=  Set Variable  ${pf} ${title} / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os}
+    ${pf}=  Run Keyword If  ${results.rc} == 0  Set Variable  \[ PASSED \]  ELSE  Set Variable  \[ FAILED \]
+    ${pf_string}=  Set Variable  ${pf}\t${title} / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os}
     Set To Dictionary  ${results_dict}  ${dict_key}  ${pf_string}
 
     Log To Console  ${results.rc}
@@ -300,7 +300,7 @@ Run Plugin Test With Config
     Log To Console  Operating System: ${os}
     Log To Console  Browser: ${selenium_browser}
     Run Keyword If  ${is_skipped}  Log To Console  Skipped...
-    Run Keyword If  ${is_skipped}  Set To Dictionary  ${PLUGIN_TEST_RESULTS_DICT}  ${dict_key}  \[SKIPPED\] Plugin test / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os} / ${selenium_browser_normalized}
+    Run Keyword If  ${is_skipped}  Set To Dictionary  ${PLUGIN_TEST_RESULTS_DICT}  ${dict_key}  \[ SKIPPED \]\tPlugin test / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os} / ${selenium_browser_normalized}
     Return From Keyword If  ${is_skipped}
     Get Testbed Information
     Set Environment Variable  VCH-NAME  %{VCH_VM_NAME}
@@ -312,7 +312,7 @@ Run Plugin Test With Config
 
     ${rc}=  Run And Return Rc  mkdir -p ${test_results_folder}
     Should Be Equal As Integers  ${rc}  0
-    Set To Dictionary  ${PLUGIN_TEST_RESULTS_DICT}  ${dict_key}  \[FAILED\] Plugin test / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os} / ${selenium_browser_normalized}
+    Set To Dictionary  ${PLUGIN_TEST_RESULTS_DICT}  ${dict_key}  \[ FAILED \] Plugin test / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os} / ${selenium_browser_normalized}
 
     # run drone
     ${drone-exec-string}=  Set Variable  drone exec --timeout \"1h0m0s\" --timeout.inactivity \"1h0m0s\" --repo.trusted .drone.local.tests.yml
@@ -323,8 +323,8 @@ Run Plugin Test With Config
 
     # set pass/fail based on return code
     Run Keyword Unless  ${results.rc} == 0  Set Global Variable  ${ALL_TESTS_PASSED}  ${FALSE}
-    ${pf}=  Run Keyword If  ${results.rc} == 0  Set Variable  \[PASSED\]  ELSE  Set Variable  \[FAILED\]
-    ${pf_string}=  Set Variable  ${pf} Plugin test / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os} / ${selenium_browser_normalized}
+    ${pf}=  Run Keyword If  ${results.rc} == 0  Set Variable  \[ PASSED \]  ELSE  Set Variable  \[ FAILED \]
+    ${pf_string}=  Set Variable  ${pf}\tPlugin test / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os} / ${selenium_browser_normalized}
     Set To Dictionary  ${PLUGIN_TEST_RESULTS_DICT}  ${dict_key}  ${pf_string}
 
     Log To Console  ${results.rc}

--- a/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -128,6 +128,15 @@ Get Latest Vic Engine Binary
 Setup Test Matrix
     # skip matrix
     @{skip_test_config_matrix}=  Create List
+    Append To List  ${skip_test_config_matrix}  60,3620759,3634791,Mac,Googlechrome,Chrome
+    Append To List  ${skip_test_config_matrix}  60,3620759,3634791,Mac,Firefox,Firefox
+    Append To List  ${skip_test_config_matrix}  60,3620759,3634791,Windows,Googlechrome,Chrome
+    Append To List  ${skip_test_config_matrix}  60,3620759,3634791,Windows,Firefox,Firefox
+    Append To List  ${skip_test_config_matrix}  60,3620759,3634791,Windows,iexplore,IE11
+    # There's currently a version clash between the Selenium standalone binary and HSUIA project
+    Append To List  ${skip_test_config_matrix}  65,5310538,5318154,Windows,Firefox,Firefox
+    # There's a H5C bug in IE11 that appears only when automatically tested
+    Append To List  ${skip_test_config_matrix}  65,5310538,5318154,Windows,IExplorer,IE11
     Set Global Variable  ${SKIP_TEST_MATRIX}  ${skip_test_config_matrix}
 
     # installer test matrix

--- a/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -248,7 +248,7 @@ Run Script Test With Config
 
     # set pass/fail based on return code
     Run Keyword Unless  ${results.rc} == 0  Set Global Variable  ${ALL_TESTS_PASSED}  ${FALSE}
-    ${pf}=  Run Keyword If  ${results.rc} == 0  Set Variable  ⭕️   ELSE  Set Variable  ❌ 
+    ${pf}=  Run Keyword If  ${results.rc} == 0  Set Variable  \[PASSED\]  ELSE  Set Variable  \[FAILED\]
     ${pf_string}=  Set Variable  ${pf} ${title} / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os}
     Set To Dictionary  ${results_dict}  ${dict_key}  ${pf_string}
 
@@ -302,7 +302,7 @@ Run Plugin Test With Config
 
     ${rc}=  Run And Return Rc  mkdir -p ${test_results_folder}
     Should Be Equal As Integers  ${rc}  0
-    Set To Dictionary  ${PLUGIN_TEST_RESULTS_DICT}  ${dict_key}  ❌ Plugin test / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os} / ${selenium_browser_normalized}
+    Set To Dictionary  ${PLUGIN_TEST_RESULTS_DICT}  ${dict_key}  \[FAILED\] Plugin test / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os} / ${selenium_browser_normalized}
 
     # run drone
     ${drone-exec-string}=  Set Variable  drone exec --timeout \"1h0m0s\" --timeout.inactivity \"1h0m0s\" --repo.trusted .drone.local.tests.yml
@@ -313,7 +313,7 @@ Run Plugin Test With Config
 
     # set pass/fail based on return code
     Run Keyword Unless  ${results.rc} == 0  Set Global Variable  ${ALL_TESTS_PASSED}  ${FALSE}
-    ${pf}=  Run Keyword If  ${results.rc} == 0  Set Variable  ⭕️   ELSE  Set Variable  ❌ 
+    ${pf}=  Run Keyword If  ${results.rc} == 0  Set Variable  \[PASSED\]  ELSE  Set Variable  \[FAILED\]
     ${pf_string}=  Set Variable  ${pf} Plugin test / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os} / ${selenium_browser_normalized}
     Set To Dictionary  ${PLUGIN_TEST_RESULTS_DICT}  ${dict_key}  ${pf_string}
 


### PR DESCRIPTION
This PR allows for skipping any existing test case. Skipped tests would be marked "SKIPPED" along with other tests marked either "PASSED" or "FAILED" in an email test report.