### PR TITLE
Escaping special chars for cli command and unused removing flags

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/general/general.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/general/general.component.ts
@@ -101,8 +101,7 @@ export class VchCreationWizardGeneralComponent implements OnInit {
         const results = {
           general: {
             name: this.form.get('name').value,
-            debug: this.form.get('debug').value,
-            vchApplianceEndpoint: `https://${this.vicApplianceIp}:${VIC_APPLIANCE_PORT}`
+            debug: this.form.get('debug').value
           }
         };
 

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/summary/summary.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/summary/summary.component.ts
@@ -145,8 +145,9 @@ export class SummaryComponent implements OnInit {
           continue;
         }
         const newKey = key.replace(camelCasePattern, '$1-$2').toLowerCase();
-        const value = payload[section][key];
+        let value = payload[section][key];
         if (typeof value === 'string') {
+          value = this.escapeSpecialCharsForCLI(value);
           if (!value.trim()) {
             continue;
           }
@@ -253,12 +254,15 @@ export class SummaryComponent implements OnInit {
     }
 
     // remove password
-
     if (results['operations']['opsPassword']) {
-      results['operations']['opsPassword'] = '*';
+      delete results['operations']['opsPassword'];
     }
 
     return results;
+  }
+
+  escapeSpecialCharsForCLI(text) {
+    return text.replace(/([() ])/g, '\\$&');
   }
 
   /**


### PR DESCRIPTION
removing password and vic-appliance-endpoint flags

escaping () and whitespace between words for CLI

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
-->
