### PR TITLE
Pass OVA url to vic-ui installer

### DIFF
--- a/scripts/VCSA/install.sh
+++ b/scripts/VCSA/install.sh
@@ -162,6 +162,7 @@ register_plugin() {
     $PLUGIN_MANAGER_BIN install --key $plugin_key \
                                 $COMMONFLAGS $plugin_flags \
                                 --thumbprint $VC_THUMBPRINT \
+                                --url $VIC_UI_HOST_URL \
                                 --server-thumbprint $VIC_UI_HOST_THUMBPRINT \
                                 --name "$plugin_name" \
                                 --summary "Plugin for $plugin_name"


### PR DESCRIPTION
This passes the url of the OVA vm to the vic-ui installer so that it can do IP verification before configuring the `ManagedBy` info. See https://github.com/vmware/vic/pull/6791.