### PR TITLE
Update Mac Mini's IP to fix broken nightly tests

### DIFF
--- a/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -393,6 +393,7 @@ Send Email
     ...    To: mwilliamson@vmware.com
     ...    To: mikeh@vmware.com
     ...    To: mhagen@vmware.com
+    ...    To: carellie@vmware.com
     ${email_to}=  Run Keyword If  ${IS_NIGHTLY_TEST}  Set Variable  ${report_recipients}  ELSE  Set Variable  To: ${whoami}@vmware.com
     ${email_body}=  Catenate  SEPARATOR=\n
     ...    ${email_to}

--- a/tests/manual-test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/vicui-common.robot
@@ -18,7 +18,7 @@ Resource  ../../resources/Util.robot
 Library  VicUiInstallPexpectLibrary.py
 
 *** Variables ***
-${MACOS_HOST_IP}                      10.20.121.192
+${MACOS_HOST_IP}                      10.20.121.66
 ${UBUNTU_HOST_IP}                     10.20.121.145
 ${WINDOWS_HOST_IP}                    10.25.200.225
 ${BUILD_3620759_IP}                   10.25.200.237
@@ -32,7 +32,7 @@ ${MACOS_HOST_USER}                    browseruser
 ${MACOS_HOST_PASSWORD}                ca*hc0w
 ${WINDOWS_HOST_USER}                  IEUser
 ${WINDOWS_HOST_PASSWORD}              Passw0rd!
-${vic_macmini_fileserver_url}         https://10.20.121.192:3443/vsphere-plugins/
+${vic_macmini_fileserver_url}         https://10.20.121.66:3443/vsphere-plugins/
 ${vic_macmini_fileserver_thumbprint}  BE:64:39:8B:BD:98:47:4D:E8:3B:2F:20:A5:21:8B:86:5F:AD:79:CE
 ${GCP_DOWNLOAD_PATH}                  https://storage.googleapis.com/vic-engine-builds/
 ${SDK_PACKAGE_ARCHIVE}                vic-ui-sdk.tar.gz

--- a/tests/manual-test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/vicui-common.robot
@@ -61,7 +61,7 @@ Load Nimbus Testbed Env
     Set Suite Variable  ${TEST_VC_PASSWORD}  %{TEST_PASSWORD}
 
 Install VIC Appliance For VIC UI
-    [Arguments]  ${vic-machine}=ui-nightly-run-bin/vic-machine-linux  ${appliance-iso}=ui-nightly-run-bin/appliance.iso  ${bootstrap-iso}=ui-nightly-run-bin/bootstrap.iso  ${certs}=${true}  ${vol}=default
+    [Arguments]  ${vic-machine}=ui-nightly-run-bin/vic-machine-linux  ${appliance-iso}=ui-nightly-run-bin/appliance.iso  ${bootstrap-iso}=ui-nightly-run-bin/bootstrap.iso  ${certs}=${false}  ${vol}=default
     Set Test Environment Variables
     # disable firewall
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.esxcli network firewall set -e false

--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -202,3 +202,117 @@ Verify Volume Inspect Info
 
     :FOR  ${item}  IN  @{checkList}
     \   Should Contain  ${mountInfo}  ${item}
+
+Log All Containers
+    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+    Run Keyword If  ${rc} != 0  Log To Console  Remaining containers - ${out}
+
+Do Images Exist
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -q
+    ${len}=  Get Length  ${output}
+    Return From Keyword If  ${len} == 0  ${false}
+    [Return]  ${true}
+
+Do Containers Exist
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a -q
+    ${len}=  Get Length  ${output}
+    Return From Keyword If  ${len} == 0  ${false}
+    [Return]  ${true}
+
+Do Volumes Exist
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -q
+    ${len}=  Get Length  ${output}
+    Return From Keyword If  ${len} == 0  ${false}
+    [Return]  ${true}
+
+Do Networks Exist
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} networks ls -q
+    ${len}=  Get Length  ${output}
+    Return From Keyword If  ${len} == 0  ${false}
+    [Return]  ${true}
+
+Remove All Containers
+    ${exist}=  Do Containers Exist
+    Run Keyword If  ${exist}  Log To Console  Stopping and removing all containers from %{VCH-NAME}
+    Return From Keyword If  ${exist} == ${false}  0
+
+    # Run Keyword If  ${exist}  Kill All Containers
+    Run Keyword If  ${exist}  Run  docker %{VCH-PARAMS} rm -f $(docker %{VCH-PARAMS} ps -a -q)
+
+    ${exist}=  Do Containers Exist
+    Return From Keyword If  ${exist} == ${false}  0
+    Run Keyword If  ${exist}  Log All Containers
+    [Return]  1
+
+Stop All Containers
+    Run  docker %{VCH-PARAMS} stop $(docker %{VCH-PARAMS} ps -q)
+
+Kill All Containers
+    Run  docker %{VCH-PARAMS} kill $(docker %{VCH-PARAMS} ps -q)
+
+Remove All Images
+    ${exist}=  Do Images Exist
+    Run Keyword If  ${exist}  Log To Console  Removing all images from %{VCH-NAME}
+    
+    Return From Keyword If  ${exist} == ${false}  0
+    Run Keyword If  ${exist}  Remove All Containers
+    Run Keyword If  ${exist}  Run  docker %{VCH-PARAMS} rmi $(docker %{VCH-PARAMS} images -q)
+
+    ${exist}=  Do Images Exist
+    Return From Keyword If  ${exist} == ${false}  0
+    [Return]  1
+
+Remove All Volumes
+    ${exist}=  Do Volumes Exist
+    Run Keyword If  ${exist}  Log To Console  Removing all volumes from %{VCH-NAME}
+
+    Return From Keyword If  ${exist} == ${false}  0
+    Run Keyword If  ${exist}  Run  docker %{VCH-PARAMS} volume rm $(docker %{VCH-PARAMS} volume ls -q)
+
+    ${exist}=  Do Volumes Exist
+    Return From Keyword If  ${exist} == ${false}  0
+    [Return]  1
+
+Remove All Container Networks
+    ${exist}=  Do Networks Exist
+    Run Keyword If  ${exist}  Log To Console  Removing all container networks from %{VCH-NAME}
+
+    Return From Keyword If  ${exist} == ${false}  0
+    Run Keyword If  ${exist}  Run  docker %{VCH-PARAMS} network rm $(docker %{VCH-PARAMS} network ls -q)
+
+    ${exist}=  Do Networks Exist
+    Return From Keyword If  ${exist} == ${false}  0
+    [Return]  1
+    
+Add List To Dictionary
+    [Arguments]  ${dict}  ${list}
+    : FOR  ${item}  IN  @{list}
+    \    Set To Dictionary  ${dict}  ${item}  1
+
+List Existing Images On VCH
+    # Get list of image IDs
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -q
+    ${len}=  Get Length  ${output}
+    Run Keyword If  ${len} != 0  Log To Console  Found images on %{VCH-NAME}:
+    ${image_ids}=  Run Keyword If  ${rc} == 0  Split String  ${output}
+    ${tags_dict}=  Create Dictionary
+    : FOR  ${id}  IN  @{image_ids}
+    \    ${rc}  ${repotags}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect --format='{{.RepoTags}}' --type=image ${id}
+    \    ${clean_tags}  Strip String  ${repotags}  characters=[]
+    \    ${tags}=  Split String  ${clean_tags}
+    \    Add List To Dictionary  ${tags_dict}  ${tags}
+
+    : FOR  ${tag}  IN  @{tags_dict.keys()}
+    \    Log To Console  \t${tag}
+
+List Running Containers On VCH    
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -q
+    Log To Console  ${EMPTY}
+    ${len}=  Get Length  ${output}
+    Run Keyword If  ${len} != 0  Log To Console  Found running containers on %{VCH-NAME}:
+    ...  ELSE  Log To Console  No running containers on %{VCH-NAME}
+    Return From Keyword If  ${len} == 0
+
+    ${cids}=  Run Keyword If  ${len} != 0  Split String  ${output}
+    : FOR  ${id}  IN  @{cids}
+    \    Log To Console  \t${id}


### PR DESCRIPTION
UI nightly tests have been broken since last night, as the Mac Mini's IP address has been changed. Eventually we will need to switch from DHCP to a static IP but until we get one we need to ensure the IP address is timely updated should it be updated.

Also this PR adds Emmanuel Carelli to the nightly test report recipients list.