### PR TITLE
Supply OVA configure option in installer

### DIFF
--- a/scripts/VCSA/install.sh
+++ b/scripts/VCSA/install.sh
@@ -159,8 +159,14 @@ register_plugin() {
     echo "Preparing to register vCenter Extension $1..."
     echo "-------------------------------------------------------------"
 
+    if [ $plugin_key == "com.vmware.vic" ]; then
+        CFLAGS="$COMMONFLAGS --configure-ova --type=VicApplianceVM"
+    else
+        CFLAGS=$COMMONFLAGS
+    fi
+
     $PLUGIN_MANAGER_BIN install --key $plugin_key \
-                                $COMMONFLAGS $plugin_flags \
+                                $CFLAGS $plugin_flags \
                                 --thumbprint $VC_THUMBPRINT \
                                 --server-thumbprint $VIC_UI_HOST_THUMBPRINT \
                                 --name "$plugin_name" \


### PR DESCRIPTION
This adds some extra flags to the install script so that the H5C UI plugin can pass them to the vic-ui binary.