### PR TITLE
Update plugin scripts to work with new vic-ui bin

### DIFF
--- a/scripts/VCSA/upgrade.sh
+++ b/scripts/VCSA/upgrade.sh
@@ -252,9 +252,15 @@ upgrade_plugin() {
     echo "Preparing to upgrade vCenter Extension $1..."
     echo "-------------------------------------------------------------"
 
+    if [ $plugin_key == "com.vmware.vic" ]; then
+        CFLAGS="$COMMONFLAGS --configure-ova --type=VicApplianceVM"
+    else
+        CFLAGS=$COMMONFLAGS
+    fi
+
     $PLUGIN_MANAGER_BIN install --force \
                                 --key $plugin_key \
-                                $COMMONFLAGS $plugin_flags \
+                                $CFLAGS $plugin_flags \
                                 --thumbprint $VC_THUMBPRINT \
                                 --server-thumbprint $VIC_UI_HOST_THUMBPRINT \
                                 --name "$plugin_name" \

--- a/scripts/vCenterForWindows/install.bat
+++ b/scripts/vCenterForWindows/install.bat
@@ -253,7 +253,7 @@ ECHO.
 ECHO -------------------------------------------------------------
 ECHO Preparing to register vCenter Extension %name:"=%-H5Client...
 ECHO -------------------------------------------------------------
-SET plugin_reg_flags=%vcenter_reg_common_flags% --name "%name:"=%-H5Client" %thumbprint_string% --version %version:"=% --summary "Plugin for %name:"=%-H5Client" --company %company% --key %key_h5c:"=% --url %vic_ui_host_url%files/%key_h5c:"=%-v%version:"=%.zip --server-thumbprint %vic_ui_host_thumbprint%
+SET plugin_reg_flags=%vcenter_reg_common_flags% --name "%name:"=%-H5Client" %thumbprint_string% --version %version:"=% --summary "Plugin for %name:"=%-H5Client" --company %company% --key %key_h5c:"=% --url %vic_ui_host_url%files/%key_h5c:"=%-v%version:"=%.zip --server-thumbprint %vic_ui_host_thumbprint% --configure-ova --type VicApplianceVM
 IF [%force_set%] == [1] (
     SET plugin_reg_flags=%plugin_reg_flags% --force
 )

--- a/scripts/vCenterForWindows/upgrade.bat
+++ b/scripts/vCenterForWindows/upgrade.bat
@@ -279,7 +279,7 @@ ECHO.
 ECHO -------------------------------------------------------------
 ECHO Preparing to register vCenter Extension %name:"=%-H5Client...
 ECHO -------------------------------------------------------------
-SET plugin_reg_flags=%vcenter_reg_common_flags% --force --name "%name:"=%-H5Client" %thumbprint_string% --version %version:"=% --summary "Plugin for %name:"=%-H5Client" --company %company% --key %key_h5c:"=% --url %vic_ui_host_url%files/%key_h5c:"=%-v%version:"=%.zip --server-thumbprint %vic_ui_host_thumbprint%
+SET plugin_reg_flags=%vcenter_reg_common_flags% --force --name "%name:"=%-H5Client" %thumbprint_string% --version %version:"=% --summary "Plugin for %name:"=%-H5Client" --company %company% --key %key_h5c:"=% --url %vic_ui_host_url%files/%key_h5c:"=%-v%version:"=%.zip --server-thumbprint %vic_ui_host_thumbprint% --configure-ova --type VicApplianceVM
 "%plugin_manager_bin%" install %plugin_reg_flags%
 IF %ERRORLEVEL% NEQ 0 (
     ECHO -------------------------------------------------------------


### PR DESCRIPTION
This PR is extended work in line with #115 such that `upgrader.sh` and corresponding Windows batch scripts behave the same as `install.sh`.