### PR TITLE
Add 'clrWizardForceForwardNavigation' option to Create VCH wizard

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.html
@@ -4,6 +4,7 @@
             class="clr-wizard--inline clr-wizard--no-shadow"
             [clrWizardPreventDefaultCancel]="true"
             clrWizardPreventModalAnimation="true"
+            [clrWizardForceForwardNavigation]="true"
             (clrWizardCurrentPageChanged)="resizeToParentFrame()"
             [clrWizardClosable]="false">
 


### PR DESCRIPTION
Since the wizard uses the next button to perform custom validations, users navigating backwards in the wizard using the steps nav is problematic, specifically when updating Summary step and CLI command values as a result of these validations. Adding this option prevents users from jumping backwards and forwards.

Fixes #135 
