### PR TITLE
Cherry-pick: Networking documentation link

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.html
@@ -5,7 +5,7 @@
   </p>
 
   <a class="btn btn-link pl-0"
-     href="https://vmware.github.io/vic-product/assets/files/html/1.1/vic_vsphere_admin/networks.html"
+     href="https://vmware.github.io/vic-product/assets/files/html/1.3/vic_vsphere_admin/vch_networking.html"
      target="_blank"
   >
     View Network Requirements


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Related to #123 Somehow this single change did not get cherry-picked. We had two PRs related to networking that overrode one another. This appears to the be the only change that didn't get updated. Setting it to be same as on master.

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
-->
