### PR TITLE
Cherry-pick: restrict wizard step navigation

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.html
@@ -4,6 +4,7 @@
             class="clr-wizard--inline clr-wizard--no-shadow"
             [clrWizardPreventDefaultCancel]="true"
             clrWizardPreventModalAnimation="true"
+            [clrWizardForceForwardNavigation]="true"
             (clrWizardCurrentPageChanged)="resizeToParentFrame()"
             [clrWizardClosable]="false">
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Since the wizard uses the next button to perform custom validations, users navigating backwards in the wizard using the steps nav is problematic, specifically when updating Summary step and CLI command values as a result of these validations. Adding this option prevents users from jumping backwards and forwards.

Fixes #135

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
-->
