### PR TITLE
Cherry-pick: Fix compute resource selector bug (#172)

### DIFF
--- a/h5c/vic/src/vic-webapp/e2e/app.po.ts
+++ b/h5c/vic/src/vic-webapp/e2e/app.po.ts
@@ -17,6 +17,7 @@ export class VicWebappPage {
 
   private actionBar = 'clr-dg-action-overflow.';
   private buttonComputeResource = 'button.cc-resource';
+  private datacenterTreenodeCaret = 'button.clr-treenode-caret';
   private buttonNewVch = 'button.new-vch';
   private iconVsphereHome = '.clr-vmw-logo';
   private iconVicShortcut = '.com_vmware_vic-home-shortcut-icon';
@@ -98,7 +99,8 @@ export class VicWebappPage {
   }
 
   selectComputeResource() {
-    this.waitForElementToBePresent(this.buttonComputeResource);
+    this.waitForElementToBePresent(this.datacenterTreenodeCaret);
+    this.clickByCSS(this.datacenterTreenodeCaret);
     this.clickByCSS(this.buttonComputeResource);
   }
 
@@ -141,7 +143,6 @@ export class VicWebappPage {
   }
 
   deleteVch(vch) {
-    browser.ignoreSynchronization = true;
     const vchActionMenu = this.actionBar + vch;
     this.waitForElementToBePresent(vchActionMenu);
     this.clickByCSS(vchActionMenu);
@@ -149,6 +150,7 @@ export class VicWebappPage {
     browser.switchTo().defaultContent();
     this.waitForElementToBePresent(this.iframeModal);
     this.switchFrame(this.iframeModal);
+    this.waitForElementToBePresent(this.labelDeleteVolumes);
     this.clickByCSS(this.labelDeleteVolumes);
     this.clickByText('Button', 'Delete');
     browser.sleep(this.defaultTimeout);

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.component.spec.ts
@@ -14,12 +14,14 @@
  limitations under the License.
 */
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {ReactiveFormsModule} from '@angular/forms';
+
 import {ClarityModule} from 'clarity-angular';
-import {HttpModule} from '@angular/http';
-import {CreateVchWizardService} from '../create-vch-wizard.service';
-import {Observable} from 'rxjs/Observable';
 import {ComputeCapacityComponent} from './compute-capacity.component';
+import { ComputeResourceTreenodeComponent } from './compute-resource-treenode.component';
+import {CreateVchWizardService} from '../create-vch-wizard.service';
+import {HttpModule} from '@angular/http';
+import {Observable} from 'rxjs/Observable';
+import {ReactiveFormsModule} from '@angular/forms';
 import {TestScheduler} from 'rxjs/Rx';
 
 describe('ComputeCapacityComponent', () => {
@@ -32,7 +34,7 @@ describe('ComputeCapacityComponent', () => {
 
   function setDefaultRequiredValues() {
     component.loadResources(component.clusters[0].text);
-    component.selectComputeResource(component.resources[0]);
+    component.selectComputeResource({datacenterObj: component.datacenter, obj: component.resources[0]});
   }
 
   beforeEach(() => {
@@ -79,7 +81,8 @@ describe('ComputeCapacityComponent', () => {
         }
       ],
       declarations: [
-        ComputeCapacityComponent
+        ComputeCapacityComponent,
+        ComputeResourceTreenodeComponent
       ]
     });
   });
@@ -87,6 +90,14 @@ describe('ComputeCapacityComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ComputeCapacityComponent);
     component = fixture.componentInstance;
+
+    spyOn(component, 'onPageLoad').and.callFake(() => {
+      component.clusters = [{
+        text: 'cluster',
+        nodeTypeId: 'DcCluster',
+        aliases: ['cluster']
+      }];
+    });
     component.onPageLoad();
 
     service = fixture.debugElement.injector.get(CreateVchWizardService);
@@ -188,7 +199,7 @@ describe('ComputeCapacityComponent', () => {
 
   it('should validate advanced fields defaults values', () => {
     component.toggleAdvancedMode();
-    component.selectComputeResource({text: ''});
+    component.selectComputeResource({datacenterObj: component.datacenter, obj: {text: ''}});
     component.onCommit();
     expect(component.form.valid).toBe(true);
 

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.component.ts
@@ -15,13 +15,16 @@
 */
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import {
+  getNumericValidatorsArray,
+  unlimitedPattern
+} from '../../shared/utils/validators';
+
+import { ComputeResource } from './compute-resource-treenode.component';
+import { CreateVchWizardService } from '../create-vch-wizard.service';
+import { DC_CLUSTER } from '../../shared/constants';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/timer';
-import { CreateVchWizardService } from '../create-vch-wizard.service';
-import {
-  unlimitedPattern,
-  getNumericValidatorsArray
-} from '../../shared/utils/validators';
 
 const endpointMemoryDefaultValue = 2048;
 
@@ -96,7 +99,6 @@ export class ComputeCapacityComponent implements OnInit {
       .getClustersList()
       .subscribe(val => {
         this.clusters = val;
-        this.isTreeLoading = false;
       });
   }
 
@@ -116,85 +118,86 @@ export class ComputeCapacityComponent implements OnInit {
 
   /**
    * Set the compute resource selected by the user.
-   * @param {any} resource
-   * @param {any?} cluster
+   * @param {obj: ComputeResource; parentClusterObj?: ComputeResource; datacenterObj: ComputeResource}
    */
-  selectComputeResource(resource: any, cluster?: any) {
-    // TODO: improve
-    this.createWzService.getDatacenter().subscribe(dcs => {
-      const datacenterName = dcs[0]['text'];
-      const nodeTypeId = resource['nodeTypeId'];
-      const isCluster = nodeTypeId === 'DcCluster';
-      let resourceObj;
-      let computeResource = `/${datacenterName}/host`;
-      if (isCluster) {
-        computeResource = `${computeResource}/${resource['text']}`;
-        resourceObj = resource['aliases'][0];
+  selectComputeResource(payload: {
+    obj: ComputeResource | any;
+    parentClusterObj?: ComputeResource | any;
+    datacenterObj: ComputeResource | any
+  }) {
+    const dcName = payload.datacenterObj.text;
+    const nodeTypeId = payload.obj.nodeTypeId
+    const isCluster = nodeTypeId === DC_CLUSTER;
+    const resourceObj = payload.obj.objRef;
 
+    let computeResource = `/${dcName}/host`;
+    let resourceObjForResourceAllocations = resourceObj;
+    if (isCluster) {
+      computeResource = `${computeResource}/${payload.obj.text}`;
+      resourceObjForResourceAllocations = payload.obj.aliases[0];
+    } else {
+      computeResource = payload.parentClusterObj ?
+        `${computeResource}/${payload.parentClusterObj.text}/${payload.obj.text}` :
+        `${computeResource}/${payload.obj.text}`;
+    }
+
+    this.selectedResourceObjRef = resourceObj;
+    this.selectedObjectName = payload.obj.text;
+    this._selectedComputeResource = computeResource;
+
+    // update resource limit & reservation info
+    this.createWzService.getResourceAllocationsInfo(resourceObjForResourceAllocations, isCluster)
+    .subscribe(response => {
+      const cpu = response['cpu'];
+      const memory = response['memory'];
+      this.resourceLimits = response;
+
+      // set max limit validator for cpu maxUsage
+      this.form.get('cpuLimit').setValidators([
+        ...getNumericValidatorsArray(true),
+        Validators.max(cpu['maxUsage'])
+      ]);
+
+      // set max limit validator for memory maxUsage
+      this.form.get('memoryLimit').setValidators([
+        ...getNumericValidatorsArray(true),
+        Validators.max(memory['maxUsage'])
+      ]);
+
+      if (this.inAdvancedMode) {
+        // set max limit validator for endpointMemory
+        this.form.get('endpointMemory').setValidators([
+          ...getNumericValidatorsArray(false),
+          Validators.max(memory['maxUsage'])
+        ]);
+
+        // set max limit validator for cpu unreservedForPool
+        this.form.get('cpuReservation').setValidators([
+          ...getNumericValidatorsArray(false),
+          Validators.max(cpu['unreservedForPool'])
+        ]);
+
+        // set max limit validator for memory unreservedForPool
+        this.form.get('memoryReservation').setValidators([
+          ...getNumericValidatorsArray(false),
+          Validators.max(memory['unreservedForPool'])
+        ]);
+
+        // This prevents the next button from getting disabled when the user selects a host or cluster that has less RAM
+        // available for VM endpoint than the default value. As a solution, we set the smaller value between the default
+        // value and memory['maxUsage']
+        this.form.get('endpointMemory').setValue(Math.min(memory['maxUsage'], endpointMemoryDefaultValue) + '');
       } else {
-        computeResource = cluster ?
-          `${computeResource}/${cluster['text']}/${resource['text']}` :
-          `${computeResource}/${resource['text']}`;
-        resourceObj = resource['objRef'];
+        this.form.get('endpointMemory').setValidators([]);
+        this.form.get('cpuReservation').setValidators([]);
+        this.form.get('memoryReservation').setValidators([]);
       }
-      this.selectedResourceObjRef = resource['objRef'];
-      this.selectedObjectName = resource['text'];
-      this._selectedComputeResource = computeResource;
 
-      // update resource limit & reservation info
-      this.createWzService.getResourceAllocationsInfo(resourceObj, isCluster)
-        .subscribe(response => {
-          const cpu = response['cpu'];
-          const memory = response['memory'];
-          this.resourceLimits = response;
-
-          // set max limit validator for cpu maxUsage
-          this.form.get('cpuLimit').setValidators([
-            ...getNumericValidatorsArray(true),
-            Validators.max(cpu['maxUsage'])
-          ]);
-
-          // set max limit validator for memory maxUsage
-          this.form.get('memoryLimit').setValidators([
-            ...getNumericValidatorsArray(true),
-            Validators.max(memory['maxUsage'])
-          ]);
-
-          if (this.inAdvancedMode) {
-            // set max limit validator for endpointMemory
-            this.form.get('endpointMemory').setValidators([
-              ...getNumericValidatorsArray(false),
-              Validators.max(memory['maxUsage'])
-            ]);
-
-            // set max limit validator for cpu unreservedForPool
-            this.form.get('cpuReservation').setValidators([
-              ...getNumericValidatorsArray(false),
-              Validators.max(cpu['unreservedForPool'])
-            ]);
-
-            // set max limit validator for memory unreservedForPool
-            this.form.get('memoryReservation').setValidators([
-              ...getNumericValidatorsArray(false),
-              Validators.max(memory['unreservedForPool'])
-            ]);
-
-            // This prevents the next button from getting disabled when the user selects a host or cluster that has less RAM
-            // available for VM endpoint than the default value. As a solution, we set the smaller value between the default
-            // value and memory['maxUsage']
-            this.form.get('endpointMemory').setValue(Math.min(memory['maxUsage'], endpointMemoryDefaultValue) + '');
-          } else {
-            this.form.get('endpointMemory').setValidators([]);
-            this.form.get('cpuReservation').setValidators([]);
-            this.form.get('memoryReservation').setValidators([]);
-          }
-
-          this.form.get('cpuLimit').updateValueAndValidity();
-          this.form.get('memoryLimit').updateValueAndValidity();
-          this.form.get('endpointMemory').updateValueAndValidity();
-          this.form.get('cpuReservation').updateValueAndValidity();
-          this.form.get('memoryReservation').updateValueAndValidity();
-        });
+      this.form.get('cpuLimit').updateValueAndValidity();
+      this.form.get('memoryLimit').updateValueAndValidity();
+      this.form.get('endpointMemory').updateValueAndValidity();
+      this.form.get('cpuReservation').updateValueAndValidity();
+      this.form.get('memoryReservation').updateValueAndValidity();
     });
   }
 
@@ -211,8 +214,6 @@ export class ComputeCapacityComponent implements OnInit {
     this.createWzService.getDatacenter().subscribe(dcs => {
       this.datacenter = dcs;
     });
-
-    this.loadClusters();
   }
 
   onCommit(): Observable<any> {

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.html
@@ -16,42 +16,22 @@
 
       </div>
       <div class="col-xs-6">
-
-        <clr-tree-node  id="compute-resource-selector"
-                        class="form-control"
-                        [class.invalid]="form.invalid && form.getError('invalidComputeResource')"
-                        [clrLoading]="isTreeLoading"
-                        (clrIfExpandedChange)="loadClusters()">
+        <ng-container>
+          <clr-tree-node id="compute-resource-selector"
+                         class="form-control"
+                         [class.invalid]="form.invalid && form.getError('invalidComputeResource')"
+                         [clrLoading]="isTreeLoading || crTreenode?.loading"
+                         *ngFor="let dc of datacenter">
             <button class="clr-treenode-link">
-                <clr-icon shape="building"></clr-icon>
-                {{ datacenter.length ? datacenter[0]['text'] : '' }}
+              <clr-icon shape="building"></clr-icon>
+              {{ dc.text }}
             </button>
-            <ng-template [clrIfExpanded]="true">
-                <clr-tree-node *ngFor="let cluster of clusters"
-                  [clrLoading]="isTreeLoading"
-                  (clrIfExpandedChange)="loadResources(cluster.objRef)">
-                  <button class="clr-treenode-link cc-resource"
-                      [class.active]="selectedObjectName === cluster['text']"
-                      (click)="selectComputeResource(cluster)">
-                    <clr-icon shape="cluster"></clr-icon>
-                    {{ cluster['text'] }}
-                  </button>
-
-                    <ng-template [clrIfExpanded]="true">
-                        <clr-tree-node *ngFor="let resource of resources">
-                            <button class="clr-treenode-link cc-resource"
-                                  [class.active]="selectedObjectName === resource['text']"
-                                  (click)="selectComputeResource(resource, cluster)">
-                            <clr-icon shape="host"></clr-icon>
-                            {{ resource['text'] }}
-                            </button>
-                        </clr-tree-node>
-
-                    </ng-template>
-                </clr-tree-node>
-            </ng-template>
-        </clr-tree-node>
-
+            <vic-compute-resource-treenode #crTreenode
+                                           [datacenter]="dc"
+                                           (resourceSelected)="selectComputeResource($event)">
+            </vic-compute-resource-treenode>
+          </clr-tree-node>
+        </ng-container>
       </div>
     </div>
 

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.component.ts
@@ -1,0 +1,111 @@
+/*
+ Copyright 2017 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { DC_CLUSTER, DC_STANDALONE_HOST } from '../../shared/constants';
+
+import { CreateVchWizardService } from '../create-vch-wizard.service';
+import { Observable } from 'rxjs/Observable';
+
+export interface ComputeResource {
+  text: string;
+  nodeTypeId: string;
+  objRef: string;
+  aliases: string[];
+}
+
+/**
+ * Component that renders a tree view of the inventory items on the selected Datacenter
+ * where Clusters, ClusterHostSystems and sstandalone hosts are displayed and selectable
+ */
+
+@Component({
+  selector: 'vic-compute-resource-treenode',
+  styleUrls: ['./compute-capacity.scss'],
+  templateUrl: './compute-resource-treenode.template.html'
+})
+export class ComputeResourceTreenodeComponent implements OnInit {
+  @Input() datacenter: ComputeResource;
+  public loading = true;
+  public clusters: ComputeResource[];
+  public clusterHostSystemsMap: {[clusterRef: string]: ComputeResource[]} = {};
+  public standaloneHosts: ComputeResource[];
+  public selectedResourceObj: ComputeResource;
+  @Output() resourceSelected: EventEmitter<{
+    obj: ComputeResource,
+    parentClusterObj?: ComputeResource,
+    datacenterObj: ComputeResource
+  }>;
+
+  constructor(
+    private createWzService: CreateVchWizardService
+  ) {
+    this.resourceSelected = new EventEmitter<{
+      obj: ComputeResource,
+      parentClusterObj?: ComputeResource,
+      datacenterObj: ComputeResource
+    }>();
+  }
+
+  ngOnInit() {
+    this.loadClusters(this.datacenter);
+  }
+
+  loadClusters(dc: ComputeResource) {
+    this.loading = true;
+    this.createWzService
+      .getClustersList()
+      .subscribe(val => {
+        this.clusters = val.filter(v => v.nodeTypeId === DC_CLUSTER);
+        this.standaloneHosts = val.filter(v => v.nodeTypeId === DC_STANDALONE_HOST);
+
+        // pointer to the current cluster object
+        // since we use concatMap the order in which we get results is guaranteed
+        let idx = 0;
+        this.createWzService.getAllClusterHostSystems(this.clusters)
+          .subscribe(clusterHostSystems => {
+            // if this is the last emission set loading var to false
+            if (idx === this.clusters.length - 1) {
+              this.loading = false;
+            }
+
+            // no host is attached to the cluster. at this point it does not make sense
+            // to display the cluster to the user, and trying to utilize the empty cluster
+            // would surely cause an error, so it makes sense to remove the cluster node from view
+            if (!clusterHostSystems.length) {
+              this.clusters = [...this.clusters.slice(0, idx), ...this.clusters.slice(idx + 1)];
+              idx++;
+              return;
+            }
+
+            this.clusterHostSystemsMap[this.clusters[idx].objRef] = clusterHostSystems;
+            idx++;
+          });
+      });
+  }
+
+  selectResource(obj: ComputeResource, clusterObj?: ComputeResource) {
+    this.selectedResourceObj = obj;
+    if (clusterObj) {
+      this.resourceSelected.emit({
+        obj: obj,
+        parentClusterObj: clusterObj,
+        datacenterObj: this.datacenter
+      });
+    } else {
+      this.resourceSelected.emit({ obj: obj, datacenterObj: this.datacenter });
+    }
+  }
+}

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.template.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.template.html
@@ -1,0 +1,38 @@
+<!-- Copyright 2017 VMware, Inc. All Rights Reserved. -->
+<ng-template [clrIfExpanded]="false">
+    <ng-container>
+      <!-- cluster and clusterhostsystems -->
+      <clr-tree-node *ngFor="let cluster of clusters"
+                     [clrLoading]="loading">
+        <button class="clr-treenode-link cc-resource"
+                [class.active]="selectedResourceObj && selectedResourceObj.objRef === cluster['objRef']"
+                (click)="selectResource(cluster)">
+          <clr-icon shape="cluster"></clr-icon>
+          {{ cluster['text'] }}
+        </button>
+
+        <ng-template [clrIfExpanded]="false">
+          <ng-container>
+            <clr-tree-node *ngFor="let clHost of clusterHostSystemsMap[cluster.objRef]">
+              <button class="clr-treenode-link cc-resource"
+                      [class.active]="selectedResourceObj && selectedResourceObj.objRef === clHost['objRef']"
+                      (click)="selectResource(clHost, cluster)">
+                <clr-icon shape="host"></clr-icon>
+                {{ clHost['text'] }}
+              </button>
+            </clr-tree-node>
+          </ng-container>
+        </ng-template>
+      </clr-tree-node>
+
+      <!-- standalone hosts -->
+      <clr-tree-node *ngFor="let host of standaloneHosts">
+        <button class="clr-treenode-link cc-resource"
+                [class.active]="selectedResourceObj && selectedResourceObj.objRef === host['objRef']"
+                (click)="selectResource(host)">
+          <clr-icon shape="host"></clr-icon>
+          {{ host['text'] }}
+        </button>
+      </clr-tree-node>
+    </ng-container>
+  </ng-template>

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.html
@@ -65,17 +65,6 @@
          target="_blank">
         <clr-icon shape="help" class="is-info"></clr-icon>
       </a>
-      <clr-alert *ngIf="errorFlag"
-                 [clrAlertType]="'alert-danger'"
-                 [clrAlertClosable]="false">
-
-        <div class="alert-item">
-          <div class="alert-text" *ngFor="let errMsg of errorMsgs">
-            {{errMsg}}
-          </div>
-        </div>
-
-      </clr-alert>
     </ng-template>
     <ng-template clrPageNavTitle>Compute Capacity</ng-template>
 
@@ -96,17 +85,6 @@
          target="_blank">
         <clr-icon shape="help" class="is-info"></clr-icon>
       </a>
-      <clr-alert *ngIf="errorFlag"
-                 [clrAlertType]="'alert-danger'"
-                 [clrAlertClosable]="false">
-
-        <div class="alert-item">
-          <div class="alert-text" *ngFor="let errMsg of errorMsgs">
-            {{errMsg}}
-          </div>
-        </div>
-
-      </clr-alert>
     </ng-template>
     <ng-template clrPageNavTitle>Storage Capacity</ng-template>
 
@@ -129,17 +107,6 @@
          target="_blank">
         <clr-icon shape="help" class="is-info"></clr-icon>
       </a>
-      <clr-alert *ngIf="errorFlag"
-                 [clrAlertType]="'alert-danger'"
-                 [clrAlertClosable]="false">
-
-        <div class="alert-item">
-          <div class="alert-text" *ngFor="let errMsg of errorMsgs">
-            {{errMsg}}
-          </div>
-        </div>
-
-      </clr-alert>
     </ng-template>
     <ng-template clrPageNavTitle>Networks</ng-template>
 
@@ -160,17 +127,6 @@
          target="_blank">
         <clr-icon shape="help" class="is-info"></clr-icon>
       </a>
-      <clr-alert *ngIf="errorFlag"
-                 [clrAlertType]="'alert-danger'"
-                 [clrAlertClosable]="false">
-
-        <div class="alert-item">
-          <div class="alert-text" *ngFor="let errMsg of errorMsgs">
-            {{errMsg}}
-          </div>
-        </div>
-
-      </clr-alert>
     </ng-template>
     <ng-template clrPageNavTitle>Security</ng-template>
 
@@ -191,17 +147,6 @@
          target="_blank">
         <clr-icon shape="help" class="is-info"></clr-icon>
       </a>
-      <clr-alert *ngIf="errorFlag"
-                 [clrAlertType]="'alert-danger'"
-                 [clrAlertClosable]="false">
-
-        <div class="alert-item">
-          <div class="alert-text" *ngFor="let errMsg of errorMsgs">
-            {{errMsg}}
-          </div>
-        </div>
-
-      </clr-alert>
     </ng-template>
     <ng-template clrPageNavTitle>Operations User</ng-template>
 

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.spec.ts
@@ -20,6 +20,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ClarityModule } from 'clarity-angular';
 import { ComputeCapacityComponent } from './compute-capacity/compute-capacity.component';
+import { ComputeResourceTreenodeComponent } from './compute-capacity/compute-resource-treenode.component';
 import { CreateVchWizardComponent } from './create-vch-wizard.component';
 import { CreateVchWizardService } from './create-vch-wizard.service';
 import { GlobalsService } from 'app/shared';
@@ -83,6 +84,7 @@ describe('CreateVchWizardComponent', () => {
         CreateVchWizardComponent,
         VchCreationWizardGeneralComponent,
         ComputeCapacityComponent,
+        ComputeResourceTreenodeComponent,
         StorageCapacityComponent,
         NetworksComponent,
         SecurityComponent,

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.module.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.module.ts
@@ -13,20 +13,22 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
-import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+
 import { ClarityModule } from 'clarity-angular';
-import { CreateVchWizardComponent } from './create-vch-wizard.component';
-import { VchCreationWizardGeneralComponent } from './general/general.component';
+import { CommonModule } from '@angular/common';
 import { ComputeCapacityComponent } from './compute-capacity/compute-capacity.component';
-import { StorageCapacityComponent } from './storage-capacity/storage-capacity.component';
-import { NetworksComponent } from './networks/networks.component';
-import { SecurityComponent } from './security/security.component';
-import { OperationsUserComponent } from './operations-user/operations-user.component';
-import { SummaryComponent } from './summary/summary.component';
+import { ComputeResourceTreenodeComponent } from './compute-capacity/compute-resource-treenode.component';
+import { CreateVchWizardComponent } from './create-vch-wizard.component';
 import { CreateVchWizardService } from './create-vch-wizard.service';
+import { NetworksComponent } from './networks/networks.component';
+import { NgModule } from '@angular/core';
+import { OperationsUserComponent } from './operations-user/operations-user.component';
+import { SecurityComponent } from './security/security.component';
+import { StorageCapacityComponent } from './storage-capacity/storage-capacity.component';
+import { SummaryComponent } from './summary/summary.component';
+import { VchCreationWizardGeneralComponent } from './general/general.component';
 
 const routes: Routes = [
   { path: '', component: CreateVchWizardComponent },
@@ -45,6 +47,7 @@ const routes: Routes = [
     CreateVchWizardComponent,
     VchCreationWizardGeneralComponent,
     ComputeCapacityComponent,
+    ComputeResourceTreenodeComponent,
     StorageCapacityComponent,
     NetworksComponent,
     SecurityComponent,
@@ -58,6 +61,7 @@ const routes: Routes = [
     CreateVchWizardComponent,
     VchCreationWizardGeneralComponent,
     ComputeCapacityComponent,
+    ComputeResourceTreenodeComponent,
     StorageCapacityComponent,
     SecurityComponent,
     OperationsUserComponent,

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/general/general.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/general/general.component.ts
@@ -95,7 +95,8 @@ export class VchCreationWizardGeneralComponent implements OnInit {
           this.form.get('name').setErrors({
             resourcePoolExists: true
           });
-          return Observable.throw(null);
+          return Observable.throw(
+            ['There is already a VirtualApp or ResourcePool that exists with the same name']);
         }
 
         const results = {

--- a/h5c/vic/src/vic-webapp/src/app/shared/constants/nodetype.ts
+++ b/h5c/vic/src/vic-webapp/src/app/shared/constants/nodetype.ts
@@ -14,9 +14,5 @@
  limitations under the License.
 */
 
-export * from './resources.path';
-export * from './portlets.text';
-export * from './vicvms';
-export * from './create-vch-wizard';
-export * from './delete-vch-modal';
-export * from './nodetype';
+export const DC_CLUSTER = 'DcCluster';
+export const DC_STANDALONE_HOST = 'DcStandaloneHost';


### PR DESCRIPTION
* Fix compute resource selector bug

* Remove redundant clr-alert comps

* Clean up

* Update protractor test to reflect changes

* Address comments

* Remove cluster from widget when no host is attached

* Safeguard getDatastores()

* Use objRef instead of alias for getting datastores

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
-->
