### PR TITLE
Cherry-pick: datacenter specific endpoint for vch logs (#209)

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/vch-view/vch-log-view/vch-log-view.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/vch-view/vch-log-view/vch-log-view.component.spec.ts
@@ -74,6 +74,11 @@ describe('VicVchLogViewComponent', () => {
             },
             acquireCloneTicket(): Observable<string> {
               return Observable.of('ticket');
+            },
+            getDatacenterForResource(): Observable<any> {
+              return Observable.of({
+                id: 'urn:vmomi:Datacenter:dc-test:00000000-0000-0000-0000-000000000000'
+              })
             }
           }
         },


### PR DESCRIPTION

* Update log request to always use datacenter in request path

Also, fix error handling for log requests since errors come in text form

* Fix VCH log view unit tests

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #209 related to #208 

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
-->
