### PR TITLE
Cherry-pick: Fix volume store CLI option name in Create wizard (#251)

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.ts
@@ -327,8 +327,8 @@ export class CreateVchWizardComponent implements OnInit {
 
     // Storage ---------------------------------------------------------------------------------------------------------
 
-    if (payload.storageCapacity.volumeStores.length) {
-      processedPayload.storage['volume_stores'] = payload.storageCapacity.volumeStores.map(vol => {
+    if (payload.storageCapacity.volumeStore.length) {
+      processedPayload.storage['volume_stores'] = payload.storageCapacity.volumeStore.map(vol => {
         return {
           datastore: vol.volDatastore + (vol.volFileFolder || ''),
           label: vol.dockerVolName

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/storage-capacity/storage-capacity.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/storage-capacity/storage-capacity.component.spec.ts
@@ -117,7 +117,7 @@ describe('StorageCapacityComponent', () => {
 
     component.onCommit().subscribe( r => {
       expect(r.storageCapacity.fileFolder).toBe(expectedFolderName);
-      expect(r.storageCapacity.volumeStores[0].volFileFolder).toBe(expectedFolderName);
+      expect(r.storageCapacity.volumeStore[0].volFileFolder).toBe(expectedFolderName);
     });
 
     // should not add an extra slash
@@ -126,7 +126,7 @@ describe('StorageCapacityComponent', () => {
 
     component.onCommit().subscribe( r => {
       expect(r.storageCapacity.fileFolder).toBe(expectedFolderName);
-      expect(r.storageCapacity.volumeStores[0].volFileFolder).toBe(expectedFolderName);
+      expect(r.storageCapacity.volumeStore[0].volFileFolder).toBe(expectedFolderName);
     });
   });
 });

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/storage-capacity/storage-capacity.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/storage-capacity/storage-capacity.component.ts
@@ -164,10 +164,10 @@ export class StorageCapacityComponent implements OnInit {
     results['baseImageSizeUnit'] = this.form.get('baseImageSizeUnit').value;
 
     // filter ones with empty datastore
-    results['volumeStores'] = this.form.get('volumeStores').value
+    results['volumeStore'] = this.form.get('volumeStores').value
       .filter(vol => vol['volDatastore']);
 
-    results['volumeStores'].forEach(vol => {
+    results['volumeStore'].forEach(vol => {
       // if volume file folder doesn't start with '/', prepend the value with '/'
       if (vol['volFileFolder'].length && vol['volFileFolder'].charAt(0) !== '/') {
         vol['volFileFolder'] = '/' + vol['volFileFolder'];

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/summary/summary.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/summary/summary.component.spec.ts
@@ -61,7 +61,7 @@ describe('SummaryComponent', () => {
       storageCapacity: {
         imageStore: 'datastore',
         baseImageSizeUnit: 'GiB',
-        volumeStores: []
+        volumeStore: []
       },
       networks: {
         containerNetworks: []

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/summary/summary.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/summary/summary.component.ts
@@ -205,8 +205,8 @@ export class SummaryComponent implements OnInit {
 
     // transform each volume store entry
 
-    const volumeStoresRef = results['storageCapacity']['volumeStores'];
-    results['storageCapacity']['volumeStores'] =
+    const volumeStoresRef = results['storageCapacity']['volumeStore'];
+    results['storageCapacity']['volumeStore'] =
       volumeStoresRef.map(volStoreObj => {
         return `${volStoreObj['volDatastore']}${volStoreObj['volFileFolder']}:${volStoreObj['dockerVolName']}`;
       });

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/summary/summary.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/summary/summary.html
@@ -125,8 +125,8 @@
             </clr-stack-content>
           </clr-stack-block>
           <!-- volume datastores -->
-          <div *ngIf="payload?.storageCapacity?.hasOwnProperty('volumeStores')">
-            <clr-stack-block *ngFor="let volStore of payload.storageCapacity.volumeStores; let i = index">
+          <div *ngIf="payload?.storageCapacity?.hasOwnProperty('volumeStore')">
+            <clr-stack-block *ngFor="let volStore of payload.storageCapacity.volumeStore; let i = index">
               <clr-stack-label>Volume datastore {{ i + 1 }}</clr-stack-label>
               <clr-stack-content>
                 {{ volStore.volDatastore }}{{ volStore.volFileFolder }}


### PR DESCRIPTION
Fix volume store CLI option name in Create wizard

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #251

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
-->
