### PR TITLE
Cherry-pick: Fix compute resource selector widget issue (#274)

### DIFF
--- a/h5c/vic/src/vic-webapp/e2e/app.po.ts
+++ b/h5c/vic/src/vic-webapp/e2e/app.po.ts
@@ -136,9 +136,8 @@ export class VicWebappPage {
 
   createVch() {
     this.clickByText('Button', 'Finish');
-    this.waitForElementToBePresent('.spinner', this.defaultTimeout);
     browser.switchTo().defaultContent();
-    this.waitForElementToBeGone(this.iframeModal, this.extendedTimeout * 3);
+    this.waitForElementToBeGone(this.iframeModal, this.extendedTimeout * 6);
     this.switchFrame(this.iframeTabs);
   }
 

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.component.ts
@@ -34,6 +34,7 @@ export interface ComputeResource {
   nodeTypeId: string;
   objRef: string;
   aliases: string[];
+  isEmpty: boolean;
 }
 
 /**
@@ -103,7 +104,7 @@ export class ComputeResourceTreenodeComponent implements OnInit {
             // to display the cluster to the user, and trying to utilize the empty cluster
             // would surely cause an error, so it makes sense to remove the cluster node from view
             if (!clusterHostSystems.length) {
-              this.clusters = [...this.clusters.slice(0, idx), ...this.clusters.slice(idx + 1)];
+              this.clusters[idx].isEmpty = true;
               idx++;
               return;
             }

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.template.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.template.html
@@ -5,6 +5,7 @@
       <clr-tree-node *ngFor="let cluster of clusters"
                      [clrLoading]="loading">
         <button #btnEl class="clr-treenode-link cc-resource"
+                *ngIf="!cluster.isEmpty"
                 (click)="selectResource($event, cluster)">
           <clr-icon shape="cluster"></clr-icon>
           {{ cluster['text'] }}

--- a/tests/resources/Vsphere-UI-Util.robot
+++ b/tests/resources/Vsphere-UI-Util.robot
@@ -50,3 +50,108 @@ Navigate To VCH Creation Wizard
     Wait Until Page Contains  Summary
     Wait Until Page Contains  Virtual Container Hosts
     Wait Until Page Contains  Containers
+
+Prepare Testbed For Protractor Tests
+    # Force the WD to be vic-ui/
+    ${wd}=  Run  pwd
+    @{wd_split}=  Split String  ${wd}  /
+    ${wd_level_len}=  Get Length  ${wd_split}
+    ${last_level_idx}=  Evaluate  ${wd_level_len} - 1
+    ${current_folder}=  Get From List  ${wd_split}  ${last_level_idx}
+    Run Keyword Unless  '${current_folder}' == 'vic-ui'  Fatal Error  Test script should be run from vic-ui/
+
+    # Check drone CLI
+    ${rc}  ${drone_ver}=  Run And Return Rc And Output  drone --version 2>&1
+    Log  Checking Drone version...
+    Log  return code: ${rc}, output: ${drone_ver}  DEBUG
+    Run Keyword If  ${rc} > ${0}  Fatal Error  Drone is required to run tests!
+    Run Keyword If  '0.5.0' not in '${drone_ver}'  Fatal Error  Drone 0.5.0 is required to run tests!
+
+    # Make sure the govc binary exists (it should not return RC 127)
+    ${rc}=  Run And Return Rc  govc
+    Should Be True  ${rc} != 127
+
+    # Ensure product OVA is deployed and ready
+    Install VIC Product OVA  6.0u2  ${BUILD_3634791_IP}  10.192.42.90  datastore1 (3)
+    Install VIC Product OVA  6.5d  ${BUILD_5318154_IP}  10.160.75.194  datastore1 (1)
+    # TODO: use 6.5u1 instance
+    # Install VIC Product OVA  6.5u1  ${BUILD_5973321_IP}  ?  ?
+    Get Vic Engine Binaries
+
+Prepare Protractor
+    [Arguments]  ${VCSA_IP}  ${SELENIUM_GRID_IP}
+    # cache the original content of the protractor configuration file
+    ${protractor_conf}=  OperatingSystem.Get File  h5c/vic/src/vic-webapp/protractor.conf.js
+    Set Global Variable  ${original_protractor_conf}  ${protractor_conf}
+
+    # point the protractor to use the provided selenium grid host
+    ${rc}  ${out}=  Run And Return Rc And Output  sed -e "s|.*baseUrl.*|baseUrl: 'https:\/\/${VCSA_IP}\/ui',|" -e "s|.*directConnect.*|seleniumAddress: 'http:\/\/${SELENIUM_GRID_IP}:4444\/wd\/hub',|" h5c/vic/src/vic-webapp/protractor.conf.js > /tmp/protractor.conf.js
+    Should Be Equal As Integers  ${rc}  0
+    Run Keyword Unless  ${rc} == 0  Log  ${out}
+    Run  cp /tmp/protractor.conf.js ./h5c/vic/src/vic-webapp/
+
+    # update app.po.ts to set the correct baseUrl
+    ${app_po_ts}=  OperatingSystem.Get File  h5c/vic/src/vic-webapp/e2e/app.po.ts
+    Set Global Variable  ${original_app_po_ts}  ${app_po_ts}
+    ${rc}  ${out}=  Run And Return Rc And Output  sed -e "s|.*return browser\.get\(.*|return browser\.get\('https:\/\/${VCSA_IP}\/ui'\);|" h5c/vic/src/vic-webapp/e2e/app.po.ts > /tmp/app.po.ts
+    Should Be Equal As Integers  ${rc}  0
+    Run Keyword Unless  ${rc} == 0  Log  ${out}
+    Run  cp /tmp/app.po.ts ./h5c/vic/src/vic-webapp/e2e/
+
+Reboot vSphere Client
+    [Arguments]  ${VCSA_IP}
+    # reboot vsphere client after installing the plugin
+    Open Connection  ${VCSA_IP}  prompt=#
+    Login  root  vmware
+    Execute Command  service-control --stop vsphere-ui
+    Execute Command  service-control --start vsphere-ui
+
+    # wait until vsphere-ui service is up and running
+    Wait Until Keyword Succeeds  20x  30s  Is vSphere Client Ready  ${VCSA_IP}
+    Log To Console  vSphere Client has booted.
+    Close connection
+
+Is vSphere Client Ready
+    [Arguments]  ${VCSA_IP}
+    Log To Console  Waiting until vSphere Client is up and ready...
+    ${out}=  Run  curl -sL https://${VCSA_IP}/ui/ -k
+    ${out_len}=  Get Length  ${out}
+    Should Be True  ${out_len} > 0
+    Should Not Contain  ${out}  Service Unavailable
+    Should Not Contain  ${out}  is still initializing
+
+Cleanup Plugins From VC
+    [Arguments]  ${VC_TARGET}  ${VCSA_FINGERPRINT}  ${VC_USERNAME}=administrator@vsphere.local  ${VC_PASSWORD}=Admin!23
+    Close All Browsers
+    Log To Console  Removing VIC UI plugins from ${VC_TARGET}...
+    # remove plugins
+    ${rc}  ${uname_v}=  Run And Return Rc And Output  uname -v
+    ${is_darwin}=  Run Keyword And Return Status  Should Contain  ${uname_v}  Darwin
+    ${vic-ui-binary}=  Set Variable If  ${is_darwin}  ./vic-ui-darwin  ./vic-ui-linux
+    ${rc1}  ${out1}=  Run And Return Rc And Output  ${vic-ui-binary} remove --thumbprint ${VCSA_FINGERPRINT} --target ${VC_TARGET} --user ${VC_USERNAME} --password ${VC_PASSWORD} --key com.vmware.vic.ui
+    ${rc2}  ${out2}=  Run And Return Rc And Output  ${vic-ui-binary} remove --thumbprint ${VCSA_FINGERPRINT} --target ${VC_TARGET} --user ${VC_USERNAME} --password ${VC_PASSWORD} --key com.vmware.vic
+    Log To Console  ${out1}
+    Log To Console  ${out2}
+
+Destroy Dangling VCHs Created By Protractor
+    [Arguments]  ${VC_TARGET}  ${VCSA_FINGERPRINT}  ${VC_USERNAME}=administrator@vsphere.local  ${VC_PASSWORD}=Admin!23
+    Set Environment Variable  GOVC_URL  ${VC_TARGET}
+    Set Environment Variable  GOVC_INSECURE  1
+    Set Environment Variable  GOVC_USERNAME  ${VC_USERNAME}
+    Set Environment Variable  GOVC_PASSWORD  ${VC_PASSWORD}
+
+    ${rc}  ${uname_v}=  Run And Return Rc And Output  uname -v
+    ${is_darwin}=  Run Keyword And Return Status  Should Contain  ${uname_v}  Darwin
+    ${vic-machine-binary}=  Set Variable If  ${is_darwin}  ./ui-nightly-run-bin/vic-machine-darwin  ./ui-nightly-run-bin/vic-machine-linux
+
+    # get a list of dangling VMs created by protractor
+    ${rc}  ${out}=  Run And Return Rc And Output  govc vm.info -json true "virtual-container-host-*" | jq -r '.VirtualMachines[].Name'
+
+    # if there are any dangling VCHs, delete them. if not, exit the keyword
+    Run Keyword Unless  ${rc} == 0  Log To Console  VC inventory is clean. No need to clean up dangling VCHs
+    Run Keyword Unless  ${rc} == 0  Return From Keyword
+    @{vms}=  Split String  ${out}  \n
+    :FOR  ${vm}  IN  @{vms}
+    \  Log To Console  Destroying VCH: ${vm}
+    \  ${rc}  ${out}=  Run And Return Rc And Output  ${vic-machine-binary} delete --name ${vm} --target ${VC_TARGET} --user ${VC_USERNAME} --password '${VC_PASSWORD}' --compute-resource Cluster --force --thumbprint ${VCSA_FINGERPRINT}
+    \  Log To Console  ${out}


### PR DESCRIPTION
* Fix indefinitely spinning spinner

* Refactor commonly used keywords wizard tests

* Remove waitForElementToBePresent for .spinner

* Clean up all dangling VCHs created by Protractor

* Add empty cluster test case into 1-01

* Write better comment for govc binary check part

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #274 

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
-->
