### PR TITLE
Get correct DV portgroups for the selected resource

### DIFF
--- a/h5c/vic/src/vic-webapp/e2e/app.po.ts
+++ b/h5c/vic/src/vic-webapp/e2e/app.po.ts
@@ -18,6 +18,7 @@ export class VicWebappPage {
   private actionBar = 'clr-dg-action-overflow.';
   private buttonComputeResource = 'button.cc-resource';
   private datacenterTreenodeCaret = 'button.clr-treenode-caret';
+  private firstDcTreenodeCaretXpath = `(//button[contains(@class,'clr-treenode-caret')])[1]/clr-icon[contains(@dir, 'right')]`;
   private buttonNewVch = 'button.new-vch';
   private iconVsphereHome = '.clr-vmw-logo';
   private iconVicShortcut = '.com_vmware_vic-home-shortcut-icon';
@@ -28,9 +29,7 @@ export class VicWebappPage {
   private iframeModal = 'div.modal-body iframe.sandbox-iframe';
   private inputOpsUser = 'input#ops-user';
   private inputOpsPassword = 'input#ops-password';
-  // TODO: replace the following line with the line below it once VIC product 1.3.1 OVA is released
-  private labelEnableSecure = 'label[for=enable-secure-access]';
-  // private labelEnableSecure = 'label[for=use-client-auth]';
+  private labelEnableSecure = 'label[for=use-client-auth]';
   private labelDeleteVolumes = 'label[for=delete-volumes]';
   private selectorImageStore = 'select#image-store-selector';
   private selectorBridgeNetwork = 'select#bridge-network-selector';
@@ -107,26 +106,30 @@ export class VicWebappPage {
     this.switchFrame(this.iframeModal);
   }
 
-  selectComputeResource() {
+  selectComputeResource(name: string = 'Cluster') {
     this.waitForElementToBePresent(this.datacenterTreenodeCaret);
-    this.clickByCSS(this.datacenterTreenodeCaret);
-    this.clickByCSS(this.buttonComputeResource);
+    element(by.xpath(this.firstDcTreenodeCaretXpath)).isPresent().then(collapsed => {
+      if (collapsed) {
+        this.clickByCSS(this.datacenterTreenodeCaret);
+      }
+    });
+
+    this.clickByXpath(`//button[text()[contains(.,'${name}')]]`);
   }
 
-  selectDatastore() {
+  selectDatastore(name: string = 'datastore1') {
     this.waitForElementToBePresent(this.selectorImageStore);
-    this.clickByText(this.selectorImageStore + ' option', 'datastore1');
-    // this.clickByCSS(this.selectorImageStore + ' option:nth-child(3)');
+    this.clickByText(this.selectorImageStore + ' option', name);
   }
 
-  selectBridgeNetwork() {
+  selectBridgeNetwork(name: string = 'bridge') {
     this.waitForElementToBePresent(this.selectorBridgeNetwork);
-    this.clickByText(this.selectorBridgeNetwork + ' option', 'bridge');
+    this.clickByText(this.selectorBridgeNetwork + ' option', name);
   }
 
-  selectPublicNetwork() {
+  selectPublicNetwork(name: string = 'network') {
     this.waitForElementToBePresent(this.selectorPublicNetwork);
-    this.clickByText(this.selectorPublicNetwork + ' option', 'network');
+    this.clickByText(this.selectorPublicNetwork + ' option', name);
   }
 
   disableSecureAccess() {
@@ -187,6 +190,17 @@ export class VicWebappPage {
       } else {
         console.log(el + ' not found');
         return false;
+      }
+    });
+  }
+
+  clickByXpath(xpath) {
+    element(by.xpath(xpath)).isPresent().then(function(result) {
+      if (result) {
+        browser.driver.findElement(by.xpath(xpath)).click();
+      } else {
+        console.log(xpath + ' not found');
+        return false
       }
     });
   }

--- a/h5c/vic/src/vic-webapp/e2e/app.po.ts
+++ b/h5c/vic/src/vic-webapp/e2e/app.po.ts
@@ -15,6 +15,8 @@ import { browser, by, element, ElementFinder } from 'protractor';
 
 export class VicWebappPage {
 
+  private h5cActionMenuToggle = 'vc-action-menu-toggle';
+  private h5cActionMenuLogOut = 'vc-action-menu-item:nth-of-type(3)';
   private actionBar = 'clr-dg-action-overflow.';
   private buttonComputeResource = 'button.cc-resource';
   private datacenterTreenodeCaret = 'button.clr-treenode-caret';
@@ -60,6 +62,12 @@ export class VicWebappPage {
     this.sendKeys(this.inputPassword, this.password);
     // submit
     this.clickByCSS(this.submit);
+  }
+
+  logOut() {
+    this.clickByCSS(this.h5cActionMenuToggle);
+    this.waitForElementToBePresent(this.h5cActionMenuLogOut);
+    this.clickByCSS(this.h5cActionMenuLogOut);
   }
 
   waitUntilStable() {

--- a/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/1-basic.e2e-spec.ts
+++ b/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/1-basic.e2e-spec.ts
@@ -46,6 +46,10 @@ describe('VCH Create Wizard - Basic', () => {
     page = new VicWebappPage();
   });
 
+  afterAll(() => {
+    page.logOut();
+  });
+
   it('should redirect to login', () => {
     page.navigateTo();
     expect(browser.getCurrentUrl()).toContain('SSO');

--- a/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/1-basic.e2e-spec.ts
+++ b/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/1-basic.e2e-spec.ts
@@ -133,14 +133,13 @@ describe('VCH Create Wizard - Basic', () => {
 
   it('should complete security step', () => {
     page.disableSecureAccess();
-    // TODO: uncomment the following 7 lines once VIC product 1.3.1 OVA is released
-  //   page.clickByText('Button', 'Next');
-  //   // check if we made it to registry access section
-  //   page.waitForElementToBePresent(sectionRegistry);
-  //   expect(element(by.css(sectionRegistry)).isPresent()).toBe(true);
-  // });
+    page.clickByText('Button', 'Next');
+    // check if we made it to registry access section
+    page.waitForElementToBePresent(sectionRegistry);
+    expect(element(by.css(sectionRegistry)).isPresent()).toBe(true);
+  });
 
-  // it('should complete registry access step', () => {
+  it('should complete registry access step', () => {
     page.clickByText('Button', 'Next');
     // check if we made it to ops user section
     page.waitForElementToBePresent(sectionOpsUser);

--- a/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/1-basic.e2e-spec.ts
+++ b/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/1-basic.e2e-spec.ts
@@ -18,23 +18,25 @@ import { browser, by, element } from 'protractor';
 
 import { JASMINE_TIMEOUT } from '../../src/app/testing/jasmine.constants';
 import { VicWebappPage } from '../app.po';
+import {
+  defaultTimeout,
+  sectionSummary,
+  sectionOpsUser,
+  sectionRegistry,
+  sectionSecurity,
+  sectionNetworks,
+  sectionStorage,
+  sectionCompute,
+  modalWizard,
+  dataGridCell,
+  iframeTabs,
+  namePrefix
+} from './common';
 
 describe('VCH Create Wizard - Basic', () => {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = JASMINE_TIMEOUT * 4;
   let page: VicWebappPage;
   let specRunId: number;
-  const defaultTimeout = 5000;
-  const sectionSummary = 'section#summary';
-  const sectionOpsUser = 'section#ops-user';
-  const sectionRegistry = 'section#registry';
-  const sectionSecurity = 'section#security';
-  const sectionNetworks = 'section#networks';
-  const sectionStorage = 'section#storage-capacity';
-  const sectionCompute = 'section#compute-capacity';
-  const modalWizard = '.clr-wizard-stepnav';
-  const dataGridCell = '.datagrid-cell';
-  const iframeTabs = 'div.outer-tab-content iframe.sandbox-iframe';
-  const namePrefix = 'virtual-container-host-';
 
   beforeAll(() => {
     specRunId = Math.floor(Math.random() * 1000) + 100;

--- a/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/2-multi-dvswitch.e2e-spec.ts
+++ b/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/2-multi-dvswitch.e2e-spec.ts
@@ -48,6 +48,10 @@ describe('VCH Create Wizard with multiple DV Switches', () => {
     page = new VicWebappPage();
   });
 
+  afterAll(() => {
+    page.logOut();
+  });
+
   it('should redirect to login', () => {
     page.navigateTo();
     expect(browser.getCurrentUrl()).toContain('SSO');

--- a/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/2-multi-dvswitch.e2e-spec.ts
+++ b/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/2-multi-dvswitch.e2e-spec.ts
@@ -38,8 +38,7 @@ describe('VCH Create Wizard with multiple DV Switches', () => {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = JASMINE_TIMEOUT;
   let page: VicWebappPage;
   let specRunId: number;
-  // TODO: set up an ESXi box and get its IP
-  const DVS_TEST_ESX_HOST_IP = '10.162.46.79';
+  const DVS_TEST_ESX_HOST_IP = process.env.TEST_ESX1_IP || '10.162.46.79';
 
   beforeAll(() => {
     specRunId = Math.floor(Math.random() * 1000) + 100;

--- a/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/2-multi-dvswitch.e2e-spec.ts
+++ b/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/2-multi-dvswitch.e2e-spec.ts
@@ -1,0 +1,248 @@
+
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import { by, browser, element } from 'protractor';
+
+import { JASMINE_TIMEOUT } from '../../src/app/testing/jasmine.constants';
+import { VicWebappPage } from '../app.po';
+import {
+  defaultTimeout,
+  sectionSummary,
+  sectionOpsUser,
+  sectionRegistry,
+  sectionSecurity,
+  sectionNetworks,
+  sectionStorage,
+  sectionCompute,
+  modalWizard,
+  dataGridCell,
+  iframeTabs,
+  namePrefix
+} from './common';
+
+describe('VCH Create Wizard with multiple DV Switches', () => {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = JASMINE_TIMEOUT;
+  let page: VicWebappPage;
+  let specRunId: number;
+  // TODO: set up an ESXi box and get its IP
+  const DVS_TEST_ESX_HOST_IP = '10.162.46.79';
+
+  beforeAll(() => {
+    specRunId = Math.floor(Math.random() * 1000) + 100;
+  });
+
+  beforeEach(() => {
+    page = new VicWebappPage();
+  });
+
+  it('should redirect to login', () => {
+    page.navigateTo();
+    expect(browser.getCurrentUrl()).toContain('SSO');
+  });
+
+  it('should login', () => {
+    page.login();
+    page.waitUntilStable();
+    expect(browser.getCurrentUrl()).toContain('/ui');
+  });
+
+  it('should navigate to vsphere home', () => {
+    page.navigateToHome();
+    expect(browser.getCurrentUrl()).toContain('vsphere');
+  });
+
+  it('should navigate to vic plugin', () => {
+    page.navigateToVicPlugin();
+    expect(browser.getCurrentUrl()).toContain('vic');
+  });
+
+  it('should navigate to summary tab', () => {
+    page.navigateToSummaryTab();
+  });
+
+  it('should navigate to vch tab', () => {
+    page.navigateToVchTab();
+    expect(browser.getCurrentUrl()).toContain('customtab-vch');
+  });
+
+  it('should open create vch wizard', () => {
+    page.openVchWizard();
+    page.waitForElementToBePresent(modalWizard);
+    expect(element(by.css(modalWizard)).isPresent()).toBe(true);
+  });
+
+  it('should input vch name', () => {
+    page.clear('#nameInput');
+    page.sendKeys('#nameInput', namePrefix + specRunId);
+  });
+
+  it('should complete general step', () => {
+    page.clickByText('Button', 'Next');
+    // check if we made it to compute capacity section
+    page.waitForElementToBePresent(sectionCompute);
+    expect(element(by.css(sectionCompute)).isPresent()).toBe(true);
+  });
+
+  it('should select "Cluster" as compute resource', () => {
+    page.selectComputeResource();
+  });
+
+  it('should complete compute capacity step', () => {
+    page.clickByText('Button', 'Next');
+    // check if we made it to storage capacity section
+    page.waitForElementToBePresent(sectionStorage);
+    expect(element(by.css(sectionStorage)).isPresent()).toBe(true);
+  });
+
+  it('should select a datastore', () => {
+    page.selectDatastore();
+  });
+
+  it('should complete storage capacity step', () => {
+    page.clickByText('Button', 'Next');
+    // check if we made it to networks section
+    page.waitForElementToBePresent(sectionNetworks);
+    expect(element(by.css(sectionNetworks)).isPresent()).toBe(true);
+  });
+
+  it('should select a bridge network', () => {
+    page.selectBridgeNetwork();
+  });
+
+  it('should select a public network', () => {
+    page.selectPublicNetwork();
+  });
+
+  it('should navigate back to compute capacity step', () => {
+    page.clickByText('Button', 'Back');
+    page.clickByText('Button', 'Back');
+    page.waitForElementToBePresent(sectionCompute);
+    expect(element(by.css(sectionCompute)).isPresent()).toBe(true);
+  });
+
+  it('should select "' + DVS_TEST_ESX_HOST_IP + '" as compute resource', () => {
+    page.selectComputeResource(DVS_TEST_ESX_HOST_IP);
+    page.clickByText('Button', 'Next');
+    page.waitForElementToBePresent(sectionStorage);
+    expect(element(by.css(sectionStorage)).isPresent()).toBe(true);
+    page.selectDatastore();
+    page.clickByText('Button', 'Next');
+    page.waitForElementToBePresent(sectionNetworks);
+    expect(element(by.css(sectionNetworks)).isPresent()).toBe(true);
+  });
+
+  it('should select "net1" as bridge network', () => {
+    page.selectBridgeNetwork('net1');
+  });
+
+  it('should select "net2" as public network', () => {
+    page.selectPublicNetwork('net2');
+  });
+
+  it('should complete networks step', () => {
+    page.clickByText('Button', 'Next');
+    // check if we made it to security section
+    page.waitForElementToBePresent(sectionSecurity);
+    expect(element(by.css(sectionSecurity)).isPresent()).toBe(true);
+  });
+
+  it('should complete security step', () => {
+    page.disableSecureAccess();
+    page.clickByText('Button', 'Next');
+    // check if we made it to registry access section
+    page.waitForElementToBePresent(sectionRegistry);
+    expect(element(by.css(sectionRegistry)).isPresent()).toBe(true);
+  });
+
+  it('should complete registry access step', () => {
+    page.clickByText('Button', 'Next');
+    // check if we made it to ops user section
+    page.waitForElementToBePresent(sectionOpsUser);
+    expect(element(by.css(sectionOpsUser)).isPresent()).toBe(true);
+  });
+
+  it('should enter ops user creds', () => {
+    page.enterOpsUserCreds();
+  });
+
+  it('should complete ops user step', () => {
+    page.clickByText('Button', 'Next');
+    // check if we made it to summary section
+    page.waitForElementToBePresent(sectionSummary);
+    expect(element(by.css(sectionSummary)).isPresent()).toBe(true);
+  });
+
+  it('should create a vch', () => {
+    page.createVch();
+  });
+
+  it('should find the new vch in datagrid', () => {
+    let vchFound = false;
+    page.waitForElementToBePresent(dataGridCell);
+    page.clickByCSS('.pagination-next');
+    page.waitForElementToBePresent(dataGridCell);
+    browser.sleep(defaultTimeout);
+    const newVch = new RegExp(namePrefix + specRunId);
+    element.all(by.css(dataGridCell)).each(function(el, index) {
+      el.isPresent().then(present => {
+        if (present) {
+          el.getText().then(function(text) {
+            if (newVch.test(text)) {
+              vchFound = true;
+            }
+          });
+        }
+      })
+    }).then(function() {
+      expect(vchFound).toBeTruthy();
+    });
+  });
+
+  it('should verify the new vch has properly started', () => {
+    browser.switchTo().defaultContent();
+    page.waitForTaskDone(namePrefix + specRunId, 'Reconfigure virtual machine').then((status) => {
+      expect(status).toBeTruthy();
+    });
+  });
+
+  it('should delete created vch', () => {
+    page.deleteVch(namePrefix + specRunId);
+  });
+
+
+  it('should verify the created vch has been deleted', () => {
+    let vchFound = false;
+    page.switchFrame(iframeTabs);
+    page.waitForElementToBePresent(dataGridCell);
+    const deletedVch = new RegExp(namePrefix + specRunId);
+    element.all(by.css(dataGridCell)).each(function(element, index) {
+      element.isPresent().then(present => {
+        if (present) {
+          element.getText().then(function(text) {
+            if (deletedVch.test(text)) {
+              vchFound = true;
+            }
+          });
+        }
+      })
+    });
+    browser.sleep(defaultTimeout);
+    browser.switchTo().defaultContent();
+    page.waitForTaskDone(namePrefix + specRunId, 'Delete resource pool');
+    expect(vchFound).toBeFalsy();
+  });
+});

--- a/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/common.ts
+++ b/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/common.ts
@@ -1,0 +1,28 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+export const defaultTimeout = 5000;
+export const sectionSummary = 'section#summary';
+export const sectionOpsUser = 'section#ops-user';
+export const sectionRegistry = 'section#registry';
+export const sectionSecurity = 'section#security';
+export const sectionNetworks = 'section#networks';
+export const sectionStorage = 'section#storage-capacity';
+export const sectionCompute = 'section#compute-capacity';
+export const modalWizard = '.clr-wizard-stepnav';
+export const dataGridCell = '.datagrid-cell';
+export const iframeTabs = 'div.outer-tab-content iframe.sandbox-iframe';
+export const namePrefix = 'virtual-container-host-';

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.html
@@ -110,7 +110,9 @@
     </ng-template>
     <ng-template clrPageNavTitle>Networks</ng-template>
 
-    <vic-vch-creation-networks #networksStep></vic-vch-creation-networks>
+    <vic-vch-creation-networks #networksStep
+                               [resourceObjName]="computeCapacityStep.selectedObjectName">
+    </vic-vch-creation-networks>
 
   </clr-wizard-page>
 

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.ts
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import { FormBuilder, FormGroup, FormArray, Validators } from '@angular/forms';
 import { Observable } from 'rxjs/Observable';
 import { CreateVchWizardService } from '../create-vch-wizard.service';
@@ -35,6 +35,8 @@ export class NetworksComponent implements OnInit {
   public inAdvancedMode = false;
   public portgroupsLoading = true;
   public portgroups: any[] = [];
+
+  @Input() resourceObjName: any;
 
   constructor(
     private formBuilder: FormBuilder,
@@ -134,9 +136,20 @@ export class NetworksComponent implements OnInit {
     });
   }
 
+  loadPortgroups(computeResourceObjName: string) {
+    this.createWzService.getDistributedPortGroups(computeResourceObjName)
+      .subscribe(v => {
+        this.portgroups = v;
+        this.form.get('bridgeNetwork').setValue('');
+        this.form.get('publicNetwork').setValue('');
+        this.form.get('clientNetwork').setValue('');
+        this.form.get('managementNetwork').setValue('');
+        this.portgroupsLoading = false;
+      }, err => console.error(err));
+  }
   onPageLoad() {
-
     if (this.portgroups.length) {
+      this.loadPortgroups(this.resourceObjName);
       return;
     }
 
@@ -261,16 +274,8 @@ export class NetworksComponent implements OnInit {
         });
       });
 
-    // load portgroups
-    this.createWzService.getDistributedPortGroups()
-      .subscribe(v => {
-        this.portgroups = v;
-        this.form.get('bridgeNetwork').setValue('');
-        this.form.get('publicNetwork').setValue('');
-        this.form.get('clientNetwork').setValue('');
-        this.form.get('managementNetwork').setValue('');
-        this.portgroupsLoading = false;
-      }, err => console.error(err));
+      // load portgroups
+      this.loadPortgroups(this.resourceObjName);
   }
 
   /**

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.ts
@@ -137,6 +137,7 @@ export class NetworksComponent implements OnInit {
   }
 
   loadPortgroups(computeResourceObjName: string) {
+    this.portgroupsLoading = true;
     this.createWzService.getDistributedPortGroups(computeResourceObjName)
       .subscribe(v => {
         this.portgroups = v;

--- a/h5c/vic/src/vic-webapp/src/app/shared/utils/array-utils.ts
+++ b/h5c/vic/src/vic-webapp/src/app/shared/utils/array-utils.ts
@@ -1,0 +1,21 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+export function flattenArray(list: Array<any>) {
+  return list.reduce((a, b) => {
+    return a.concat(Array.isArray(b) ? flattenArray(b) : b);
+  }, [])
+}

--- a/tests/manual-test-cases/Group1-VCH-Creation-Wizard/1-02-Multi-DVS-VCH-Create.robot
+++ b/tests/manual-test-cases/Group1-VCH-Creation-Wizard/1-02-Multi-DVS-VCH-Create.robot
@@ -1,0 +1,88 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 1-02 - Multi DVS VCH Create
+Resource  ../../resources/Util.robot
+Resource  ../Group18-VIC-UI/vicui-common.robot
+Suite Setup  Prepare Testbed For Protractor Tests
+Suite Teardown  Cleanup Testbed After Protractor Test Completes
+
+*** Variables ***
+${OVA_UTIL_ROBOT}  https://github.com/vmware/vic-product/raw/master/tests/resources/OVA-Util.robot
+${DVS_TEST_ESX_HOST_IP}  10.162.46.79
+
+*** Keywords ***
+Cleanup Testbed After Protractor Test Completes
+    # Delete all vic-machine generated artifacts
+    Run  rm -rf VCH-0*
+
+    # Revert some modified local files
+    Run  git reset --hard HEAD 2>&1
+
+    # Delete binaries
+    Run  rm -rf vic*.tar.gz ui-nightly-run-bin
+    Run  rm -rf scripts/plugin-packages/com.vmware.vic-v1*
+    Run  rm -rf scripts/vsphere-client-serenity/com.vmware.vic.ui-v1*
+
+    # delete plugins from VC
+    Cleanup Plugins From VC  ${TEST_VC_IP}  %{VC_FINGERPRINT}  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}
+
+    # delete all dangling VCHs
+    Destroy Dangling VCHs Created By Protractor  ${TEST_VC_IP}  %{VC_FINGERPRINT}  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}
+
+    Run  govc object.destroy '/Datacenter/network/DSwitch 2'
+
+
+*** Test Cases ***
+[ Windows 10 - Chrome ] Create a VCH on a Multi Distributed Switches Environment
+    Set Environment Variable  TEST_VCSA_BUILD  7312210
+    Set Environment Variable  TEST_VSPHERE_VER  65
+    Set Environment Variable  VC_FINGERPRINT  ${VC_FINGERPRINT_7312210}
+    Set Global Variable  ${TEST_VC_IP}  ${BUILD_7312210_IP}
+    Set Global Variable  ${TEST_VC_USERNAME}  administrator@vsphere.local
+    Set Global Variable  ${TEST_VC_PASSWORD}  Admin!23
+
+    # create a new distributed switch and add a new host
+    Run  govc object.destroy '/Datacenter/network/DSwitch 2'
+    ${rc}=  Run And Return Rc  govc dvs.create -dc=Datacenter 'DSwitch 2'
+    Should Be Equal As Integers  ${rc}  0
+
+    # create port groups: net1, net2
+    ${rc}  ${out}=  Run And Return Rc And Output  govc dvs.portgroup.add -nports 12 -dc=Datacenter -dvs='DSwitch 2' net1
+    Should Be Equal As Integers  ${rc}  0
+    Log To Console  ${out}
+    ${rc}  ${out}=  Run And Return Rc And Output  govc dvs.portgroup.add -nports 12 -dc=Datacenter -dvs='DSwitch 2' net2
+    Should Be Equal As Integers  ${rc}  0
+    Log To Console  ${out}
+    # add ${DVS_TEST_ESX_HOST_IP} to DSwitch 2
+    ${rc}  ${out}=  Run And Return Rc And Output  govc dvs.add -dvs='DSwitch 2' -pnic=vmnic1 -host.ip=${DVS_TEST_ESX_HOST_IP} ${DVS_TEST_ESX_HOST_IP}
+    Should Be Equal As Integers  ${rc}  0
+    Log To Console  ${out}
+
+    # install the plugin only the first time
+    Set Absolute Script Paths  ./scripts
+    Force Install Vicui Plugin
+    Reboot vSphere Client  ${TEST_VC_IP}
+
+    Log To Console  OVA IP is %{OVA_IP_6.5u1d}
+    Prepare Protractor  ${BUILD_7312210_IP}  ${WINDOWS_HOST_IP}  chrome
+
+    # run protractor
+    ${rc}  ${out}=  Run And Return Rc And Output  cd h5c/vic/src/vic-webapp && yarn && npm run e2e -- --specs=e2e/vch-create-wizard/2-multi-dvswitch.e2e-spec.ts
+    Log  ${out}
+    Log To Console  ${out}
+
+    # report pass/fail
+    Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
Fixes #307 

Test steps:
1. Make sure distributed virtual switch named "DSwitch 2" is not in the VC inventory
    1. govc object.destroy '/Datacenter/network/DSwitch 2
2. Create a new distributed virtual switch named "DSwitch 2"
    1. govc dvs.create -dc=Datacenter 'DSwitch 2'
3. Create port groups: net1, net2
    1. govc dvs.portgroup.add -nports 12 -dc=Datacenter -dvs='DSwitch 2' net1
    2. govc dvs.portgroup.add -nports 12 -dc=Datacenter -dvs='DSwitch 2' net2
4. Add an idle standalone host to "DSwitch 2" (make sure to add the host to the VC beforehand!)
    1. govc dvs.add -dvs='DSwitch 2' -pnic=vmnic1 -host.ip=$HOST_IP $HOST_IP
5. Open the VCH Create wizard and select "Cluster" as compute resource
6. Proceed to the "Networks" section, select port groups "bridge" and "network" for the bridge and public networks
7. Navigate backwards to the "Compute Capacity" section and select the standalone host
8. Proceed to the "Capacity section" and select a datastore that has name starting with "datastore1"
9. Proceed to the "Networks" section and select "net1" for bridge and "net2" for public networks
10. Continue through the rest of the steps to finish creating a VCH
11. Check if the VCH is created successfully and delete it once it's created