### PR TITLE
Switch from on-prem server to Nimbus for nightly testbed VMs

### DIFF
--- a/.drone.local.script.yml
+++ b/.drone.local.script.yml
@@ -18,16 +18,16 @@ pipeline:
       TEST_RESOURCE: ${TEST_RESOURCE}
       GOVC_INSECURE: true
       BUILD_NUMBER: ${buildNumber}
-      TEST_VSPHERE_VER: #TEST_VSPHERE_VER
-      TEST_VCSA_BUILD: #TEST_VCSA_BUILD
-      TEST_OS: #TEST_OS
+      TEST_VSPHERE_VER: '#TEST_VSPHERE_VER'
+      TEST_VCSA_BUILD: '#TEST_VCSA_BUILD'
+      TEST_OS: '#TEST_OS'
       UI_TEST_CASES_FOLDER: tests/test-cases/Group18-VIC-UI
-      TEST_RESULTS_FOLDER: #TEST_RESULTS_FOLDER
-      ROBOT_SCRIPT: #ROBOT_SCRIPT
+      TEST_RESULTS_FOLDER: '#TEST_RESULTS_FOLDER'
+      ROBOT_SCRIPT: '#ROBOT_SCRIPT'
     commands:
-      - set -e
-      - pip install pexpect
-      - cd $UI_TEST_CASES_FOLDER
-      - if [ $TEST_OS = "Mac" ] ; then robot --log container_log.html --report container_report.html --output container_output.xml --test *Mac -C ansi -d ../../../$TEST_RESULTS_FOLDER $ROBOT_SCRIPT ; fi
-      - if [ $TEST_OS = "Ubuntu" ] ; then robot --include anyos --include unixlike --test TestCase-* -C ansi -d ../../../$TEST_RESULTS_FOLDER $ROBOT_SCRIPT ; fi
-      - if [ $TEST_OS = "Windows" ] ; then robot --log container_log.html --report container_report.html --output container_output.xml --test *Windows -C ansi -d ../../../$TEST_RESULTS_FOLDER $ROBOT_SCRIPT ; fi
+      - 'set -e'
+      - 'pip install pexpect'
+      - 'cd $UI_TEST_CASES_FOLDER'
+      - 'if [ $TEST_OS = "Mac" ] ; then robot --log container_log.html --report container_report.html --output container_output.xml --test *Mac -C ansi -d ../../../$TEST_RESULTS_FOLDER $ROBOT_SCRIPT ; fi'
+      - 'if [ $TEST_OS = "Ubuntu" ] ; then robot --include anyos --include unixlike --test TestCase-* -C ansi -d ../../../$TEST_RESULTS_FOLDER $ROBOT_SCRIPT ; fi'
+      - 'if [ $TEST_OS = "Windows" ] ; then robot --log container_log.html --report container_report.html --output container_output.xml --test *Windows -C ansi -d ../../../$TEST_RESULTS_FOLDER $ROBOT_SCRIPT ; fi'

--- a/.drone.local.script.yml
+++ b/.drone.local.script.yml
@@ -26,7 +26,6 @@ pipeline:
       ROBOT_SCRIPT: #ROBOT_SCRIPT
     commands:
       - set -e
-      - export $(cat testbed-information-${BUILD_NUMBER} | xargs)
       - pip install pexpect
       - cd $UI_TEST_CASES_FOLDER
       - if [ $TEST_OS = "Mac" ] ; then robot --log container_log.html --report container_report.html --output container_output.xml --test *Mac -C ansi -d ../../../$TEST_RESULTS_FOLDER $ROBOT_SCRIPT ; fi

--- a/.drone.local.script.yml
+++ b/.drone.local.script.yml
@@ -8,22 +8,26 @@ pipeline:
     tags: true
     recursive: false
   vic-uia:
-    image: 'gcr.io/eminent-nation-87317/vic-integration-test:1.33'
+    image: ${TEST_BUILD_IMAGE=gcr.io/eminent-nation-87317/vic-integration-test:1.33}
     pull: true
     environment:
       BIN: bin
       GOPATH: /go
       SHELL: /bin/bash
-      TEST_VSPHERE_VER: '#TEST_VSPHERE_VER'
-      TEST_VCSA_BUILD: '#TEST_VCSA_BUILD'
-      TEST_OS: '#TEST_OS'
+      TEST_DATASTORE: ${TEST_DATASTORE}
+      TEST_RESOURCE: ${TEST_RESOURCE}
+      GOVC_INSECURE: true
+      BUILD_NUMBER: ${buildNumber}
+      TEST_VSPHERE_VER: #TEST_VSPHERE_VER
+      TEST_VCSA_BUILD: #TEST_VCSA_BUILD
+      TEST_OS: #TEST_OS
       UI_TEST_CASES_FOLDER: tests/test-cases/Group18-VIC-UI
-      TEST_RESULTS_FOLDER: '#TEST_RESULTS_FOLDER'
-      ROBOT_SCRIPT: '#ROBOT_SCRIPT'
+      TEST_RESULTS_FOLDER: #TEST_RESULTS_FOLDER
+      ROBOT_SCRIPT: #ROBOT_SCRIPT
     commands:
-      - 'set -e'
-      - 'pip install pexpect'
-      - 'cd $UI_TEST_CASES_FOLDER'
-      - 'if [ $TEST_OS = "Mac" ] ; then robot --log container_log.html --report container_report.html --output container_output.xml --test *Mac -C ansi -d ../../../$TEST_RESULTS_FOLDER $ROBOT_SCRIPT ; fi'
-      - 'if [ $TEST_OS = "Ubuntu" ] ; then robot --include anyos --include unixlike --test TestCase-* -C ansi -d ../../../$TEST_RESULTS_FOLDER $ROBOT_SCRIPT ; fi'
-      - 'if [ $TEST_OS = "Windows" ] ; then robot --log container_log.html --report container_report.html --output container_output.xml --test *Windows -C ansi -d ../../../$TEST_RESULTS_FOLDER $ROBOT_SCRIPT ; fi'
+      - set -e
+      - pip install pexpect
+      - cd $UI_TEST_CASES_FOLDER
+      - if [ $TEST_OS = "Mac" ] ; then robot --log container_log.html --report container_report.html --output container_output.xml --test *Mac -C ansi -d ../../../$TEST_RESULTS_FOLDER $ROBOT_SCRIPT ; fi
+      - if [ $TEST_OS = "Ubuntu" ] ; then robot --include anyos --include unixlike --test TestCase-* -C ansi -d ../../../$TEST_RESULTS_FOLDER $ROBOT_SCRIPT ; fi
+      - if [ $TEST_OS = "Windows" ] ; then robot --log container_log.html --report container_report.html --output container_output.xml --test *Windows -C ansi -d ../../../$TEST_RESULTS_FOLDER $ROBOT_SCRIPT ; fi

--- a/.drone.local.script.yml
+++ b/.drone.local.script.yml
@@ -17,7 +17,7 @@ pipeline:
       TEST_DATASTORE: ${TEST_DATASTORE}
       TEST_RESOURCE: ${TEST_RESOURCE}
       GOVC_INSECURE: true
-      BUILD_NUMBER: ${buildNumber}
+      BUILD_NUMBER: #BUILD_NUMBER
       TEST_VSPHERE_VER: #TEST_VSPHERE_VER
       TEST_VCSA_BUILD: #TEST_VCSA_BUILD
       TEST_OS: #TEST_OS
@@ -26,6 +26,7 @@ pipeline:
       ROBOT_SCRIPT: #ROBOT_SCRIPT
     commands:
       - set -e
+      - export $(cat testbed-information-${BUILD_NUMBER} | xargs)
       - pip install pexpect
       - cd $UI_TEST_CASES_FOLDER
       - if [ $TEST_OS = "Mac" ] ; then robot --log container_log.html --report container_report.html --output container_output.xml --test *Mac -C ansi -d ../../../$TEST_RESULTS_FOLDER $ROBOT_SCRIPT ; fi

--- a/.drone.local.script.yml
+++ b/.drone.local.script.yml
@@ -8,16 +8,12 @@ pipeline:
     tags: true
     recursive: false
   vic-uia:
-    image: ${TEST_BUILD_IMAGE=gcr.io/eminent-nation-87317/vic-integration-test:1.33}
+    image: 'gcr.io/eminent-nation-87317/vic-integration-test:1.33'
     pull: true
     environment:
       BIN: bin
       GOPATH: /go
       SHELL: /bin/bash
-      TEST_DATASTORE: ${TEST_DATASTORE}
-      TEST_RESOURCE: ${TEST_RESOURCE}
-      GOVC_INSECURE: true
-      BUILD_NUMBER: ${buildNumber}
       TEST_VSPHERE_VER: '#TEST_VSPHERE_VER'
       TEST_VCSA_BUILD: '#TEST_VCSA_BUILD'
       TEST_OS: '#TEST_OS'

--- a/h5c/build-deployable.xml
+++ b/h5c/build-deployable.xml
@@ -45,10 +45,7 @@
       <condition property="BUILD_MODE" value="prod" else="dev">
          <equals arg1="prod" arg2="${env.BUILD_MODE}" casesensitive="false"/>
       </condition>
-      <condition property="ANGULAR_APP_ROOT" value="dist" else="build-dev">
-         <equals arg1="${BUILD_MODE}" arg2="prod" casesensitive="false"/>
-      </condition>
-      <replaceregexp file="${basedir}/vic/src/main/webapp/plugin.xml" match="(\/vsphere-client\/vic\/resources\/)(build\-dev|dist)" replace="\1${ANGULAR_APP_ROOT}" byline="true"/>
+      <replaceregexp file="${basedir}/vic/src/main/webapp/plugin.xml" match="(\/vsphere-client\/vic\/resources\/)(build\-dev|dist)" replace="\1dist" byline="true"/>
       <echo>Build mode is ${BUILD_MODE}</echo>
    </target>
 

--- a/h5c/vic/src/vic-webapp/e2e/app.po.ts
+++ b/h5c/vic/src/vic-webapp/e2e/app.po.ts
@@ -39,7 +39,7 @@ export class VicWebappPage {
   private inputUsername = '#username';
   private username = 'administrator@vsphere.local';
   private inputPassword = '#password';
-  private password = 'Admin!23';
+  private password = 'Bl*ckwalnut0';
   private submit = '#submit';
   private defaultTimeout = 5000;
   private extendedTimeout = 10000;

--- a/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/1-basic.e2e-spec.ts
+++ b/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/1-basic.e2e-spec.ts
@@ -196,11 +196,10 @@ describe('VCH Create Wizard - Basic', () => {
 
   it('should redirect to VCH VM and display Create Wizard menu items', () => {
     page.navigateToVchVm(namePrefix + specRunId);
-    // wait for VM summary page to be ready
-    browser.wait(function () {
-      return browser.isElementPresent(by.cssContainingText('.summary-name-label', namePrefix + specRunId));
-    }, defaultTimeout * 6);
-    page.clickByCSS('.summary-action-link');
+    browser.switchTo().defaultContent();
+    browser.sleep(defaultTimeout);
+    page.waitForElementToBePresent('a.summary-action-link');
+    page.clickByCSS('a.summary-action-link');
     // wait for menu items to be calculated
     browser.sleep(defaultTimeout);
     page.clickByText('#applicationMenuContainer .k-item .k-link', 'All VIC Actions');

--- a/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/2-multi-dvswitch.e2e-spec.ts
+++ b/h5c/vic/src/vic-webapp/e2e/vch-create-wizard/2-multi-dvswitch.e2e-spec.ts
@@ -38,7 +38,7 @@ describe('VCH Create Wizard with multiple DV Switches', () => {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = PROTRACTOR_JASMINE_TIMEOUT;
   let page: VicWebappPage;
   let specRunId: number;
-  const DVS_TEST_ESX_HOST_IP = process.env.TEST_ESX1_IP || '10.192.103.50';
+  const DVS_TEST_ESX_HOST_IP = process.env.STANDALONE_ESX1_IP;
 
   beforeAll(() => {
     specRunId = Math.floor(Math.random() * 1000) + 100;

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -184,9 +184,10 @@ Deploy Nimbus Testbed
 
 Kill Nimbus Server
     [Arguments]  ${user}  ${password}  ${name}
-    Open SSH Connection  %{NIMBUS_GW}  %{user}  %{password}  retry_interval=30 sec
+    Open SSH Connection  %{NIMBUS_GW}  ${user}  ${password}  retry_interval=30 sec
     ${out}=  Execute Command  nimbus-ctl kill ${name}
     Close connection
+    [Return]  ${out}
 
 Cleanup Nimbus PXE folder
     [Arguments]  ${user}  ${password}

--- a/tests/resources/Vsphere-UI-Util.robot
+++ b/tests/resources/Vsphere-UI-Util.robot
@@ -132,7 +132,7 @@ Is vSphere Client Ready
     Should Not Contain  ${out}  is still initializing
 
 Cleanup Plugins From VC
-    [Arguments]  ${VC_TARGET}  ${VCSA_FINGERPRINT}  ${VC_USERNAME}=administrator@vsphere.local  ${VC_PASSWORD}=Admin!23
+    [Arguments]  ${VC_TARGET}  ${VCSA_FINGERPRINT}  ${VC_USERNAME}=administrator@vsphere.local  ${VC_PASSWORD}=Bl*ckwalnut0
     Close All Browsers
     Log To Console  Removing VIC UI plugins from ${VC_TARGET}...
     # remove plugins
@@ -145,7 +145,7 @@ Cleanup Plugins From VC
     Log To Console  ${out2}
 
 Destroy Dangling VCHs Created By Protractor
-    [Arguments]  ${VC_TARGET}  ${VCSA_FINGERPRINT}  ${VC_USERNAME}=administrator@vsphere.local  ${VC_PASSWORD}=Admin!23
+    [Arguments]  ${VC_TARGET}  ${VCSA_FINGERPRINT}  ${VC_USERNAME}=administrator@vsphere.local  ${VC_PASSWORD}=Bl*ckwalnut0
     Set Environment Variable  GOVC_URL  ${VC_TARGET}
     Set Environment Variable  GOVC_INSECURE  1
     Set Environment Variable  GOVC_USERNAME  ${VC_USERNAME}

--- a/tests/resources/Vsphere-UI-Util.robot
+++ b/tests/resources/Vsphere-UI-Util.robot
@@ -76,6 +76,8 @@ Prepare Testbed For Protractor Tests
     Set Global Variable  ${TEST_VC_USERNAME}  %{TEST_USERNAME}
     Set Global Variable  ${TEST_VC_PASSWORD}  %{TEST_PASSWORD}
 
+    Register VC CA Cert With Windows  ${TEST_VC_IP}
+
 Prepare Protractor
     [Arguments]  ${VCSA_IP}  ${SELENIUM_GRID_IP}  ${BROWSER}
     # cache the original content of the protractor configuration file

--- a/tests/resources/Vsphere-UI-Util.robot
+++ b/tests/resources/Vsphere-UI-Util.robot
@@ -65,15 +65,16 @@ Prepare Testbed For Protractor Tests
     Log  Checking Drone version...
     Log  return code: ${rc}, output: ${drone_ver}  DEBUG
     Run Keyword If  ${rc} > ${0}  Fatal Error  Drone is required to run tests!
-    Run Keyword If  '0.5.0' not in '${drone_ver}'  Fatal Error  Drone 0.5.0 is required to run tests!
 
     # Make sure the govc binary exists (it should not return RC 127)
     ${rc}=  Run And Return Rc  govc
     Should Be True  ${rc} != 127
 
-    # Ensure product OVA is deployed and ready
-    Install VIC Product OVA  6.5u1d  ${BUILD_7312210_IP}  %{OVA_ESX_IP_VC65U1D}  %{OVA_ESX_DATASTORE_VC65U1D}
-    Get Vic Engine Binaries
+    Load Nimbus Testbed Env  testbed-information-%{BUILD_NUMBER}
+    Set Environment Variable  TEST_VCSA_BUILD  7515524
+    Set Environment Variable  OVA_IP_%{BUILD_NUMBER}  %{OVA_IP}
+    Set Global Variable  ${TEST_VC_USERNAME}  %{TEST_USERNAME}
+    Set Global Variable  ${TEST_VC_PASSWORD}  %{TEST_PASSWORD}
 
 Prepare Protractor
     [Arguments]  ${VCSA_IP}  ${SELENIUM_GRID_IP}  ${BROWSER}

--- a/tests/test-cases/Group1-VCH-Creation-Wizard/1-01-Basic-VCH-Create.robot
+++ b/tests/test-cases/Group1-VCH-Creation-Wizard/1-01-Basic-VCH-Create.robot
@@ -16,7 +16,7 @@
 Documentation  Test 1-01 - Basic VCH Create
 Resource  ../../resources/Util.robot
 Resource  ../Group18-VIC-UI/vicui-common.robot
-Suite Setup  Prepare Testbed For Protractor Tests
+Suite Setup  Prepare Testbed For Protractor Tests And Install Plugin
 Suite Teardown  Cleanup Testbed After Protractor Test Completes
 
 *** Variables ***
@@ -48,13 +48,14 @@ Cleanup Testbed After Protractor Test Completes
     Run  govc object.destroy -dc Datacenter /Datacenter/host/Cluster3
     Run  govc object.destroy -dc Datacenter2 /Datacenter2
 
-*** Test Cases ***
-[ Windows 10 - Chrome ] Create And Delete VCH On A Single Cluster Environment
-    # install the plugin only the first time
+Prepare Testbed For Protractor Tests And Install Plugin
+    Prepare Testbed For Protractor Tests
     Set Absolute Script Paths  ./scripts
     Force Install Vicui Plugin  .
     Reboot vSphere Client  ${TEST_VC_IP}
 
+*** Test Cases ***
+[ Windows 10 - Chrome ] Create And Delete VCH On A Single Cluster Environment
     Log To Console  OVA IP is %{OVA_IP}
     Prepare Protractor  ${TEST_VC_IP}  ${WINDOWS_HOST_IP}  chrome
 

--- a/tests/test-cases/Group1-VCH-Creation-Wizard/1-01-Basic-VCH-Create.robot
+++ b/tests/test-cases/Group1-VCH-Creation-Wizard/1-01-Basic-VCH-Create.robot
@@ -24,6 +24,8 @@ ${OVA_UTIL_ROBOT}  https://github.com/vmware/vic-product/raw/master/tests/resour
 
 *** Keywords ***
 Cleanup Testbed After Protractor Test Completes
+    Delete VC Root CA
+
     # Delete all vic-machine generated artifacts
     Run  rm -rf VCH-0*
 

--- a/tests/test-cases/Group1-VCH-Creation-Wizard/1-01-Basic-VCH-Create.robot
+++ b/tests/test-cases/Group1-VCH-Creation-Wizard/1-01-Basic-VCH-Create.robot
@@ -31,7 +31,7 @@ Cleanup Testbed After Protractor Test Completes
     Run  git reset --hard HEAD 2>&1
 
     # Delete binaries
-    Run  rm -rf vic*.tar.gz ui-nightly-run-bin
+    Run  rm -rf vic*.tar.gz
     Run  rm -rf scripts/plugin-packages/com.vmware.vic-v1*
     Run  rm -rf scripts/vsphere-client-serenity/com.vmware.vic.ui-v1*
 
@@ -48,20 +48,13 @@ Cleanup Testbed After Protractor Test Completes
 
 *** Test Cases ***
 [ Windows 10 - Chrome ] Create And Delete VCH On A Single Cluster Environment
-    Set Environment Variable  TEST_VCSA_BUILD  7312210
-    Set Environment Variable  TEST_VSPHERE_VER  65
-    Set Environment Variable  VC_FINGERPRINT  ${VC_FINGERPRINT_7312210}
-    Set Global Variable  ${TEST_VC_IP}  ${BUILD_7312210_IP}
-    Set Global Variable  ${TEST_VC_USERNAME}  administrator@vsphere.local
-    Set Global Variable  ${TEST_VC_PASSWORD}  Admin!23
-
     # install the plugin only the first time
     Set Absolute Script Paths  ./scripts
-    Force Install Vicui Plugin
+    Force Install Vicui Plugin  .
     Reboot vSphere Client  ${TEST_VC_IP}
 
-    Log To Console  OVA IP is %{OVA_IP_6.5u1d}
-    Prepare Protractor  ${BUILD_7312210_IP}  ${WINDOWS_HOST_IP}  chrome
+    Log To Console  OVA IP is %{OVA_IP}
+    Prepare Protractor  ${TEST_VC_IP}  ${WINDOWS_HOST_IP}  chrome
 
     # run protractor
     ${rc}  ${out}=  Run And Return Rc And Output  cd h5c/vic/src/vic-webapp && yarn && npm run e2e -- --specs=e2e/vch-create-wizard/1-basic.e2e-spec.ts
@@ -72,8 +65,8 @@ Cleanup Testbed After Protractor Test Completes
     Should Be Equal As Integers  ${rc}  0
 
 [ Windows 10 - Firefox ] Create And Delete VCH On A Single Cluster Environment
-    Log To Console  OVA IP is %{OVA_IP_6.5u1d}
-    Prepare Protractor  ${BUILD_7312210_IP}  ${WINDOWS_HOST_IP}  firefox
+    Log To Console  OVA IP is %{OVA_IP}
+    Prepare Protractor  ${TEST_VC_IP}  ${WINDOWS_HOST_IP}  firefox
 
     # run protractor
     ${rc}  ${out}=  Run And Return Rc And Output  cd h5c/vic/src/vic-webapp && yarn && npm run e2e -- --specs=e2e/vch-create-wizard/1-basic.e2e-spec.ts
@@ -84,8 +77,8 @@ Cleanup Testbed After Protractor Test Completes
     Should Be Equal As Integers  ${rc}  0
 
 [ Windows 10 - IE11 ] Create And Delete VCH On A Single Cluster Environment
-    Log To Console  OVA IP is %{OVA_IP_6.5u1d}
-    Prepare Protractor  ${BUILD_7312210_IP}  ${WINDOWS_HOST_IP}  internet explorer
+    Log To Console  OVA IP is %{OVA_IP}
+    Prepare Protractor  ${TEST_VC_IP}  ${WINDOWS_HOST_IP}  internet explorer
 
     # run protractor
     ${rc}  ${out}=  Run And Return Rc And Output  cd h5c/vic/src/vic-webapp && yarn && npm run e2e -- --specs=e2e/vch-create-wizard/1-basic.e2e-spec.ts
@@ -96,8 +89,8 @@ Cleanup Testbed After Protractor Test Completes
     Should Be Equal As Integers  ${rc}  0
 
 [ MacOS - Chrome ] Create And Delete VCH On A Single Cluster Environment
-    Log To Console  OVA IP is %{OVA_IP_6.5u1d}
-    Prepare Protractor  ${BUILD_7312210_IP}  ${MACOS_HOST_IP}  chrome
+    Log To Console  OVA IP is %{OVA_IP}
+    Prepare Protractor  ${TEST_VC_IP}  ${MACOS_HOST_IP}  chrome
 
     # run protractor
     ${rc}  ${out}=  Run And Return Rc And Output  cd h5c/vic/src/vic-webapp && yarn && npm run e2e -- --specs=e2e/vch-create-wizard/1-basic.e2e-spec.ts
@@ -108,8 +101,8 @@ Cleanup Testbed After Protractor Test Completes
     Should Be Equal As Integers  ${rc}  0
 
 [ MacOS - Firefox ] Create And Delete VCH On A Single Cluster Environment
-    Log To Console  OVA IP is %{OVA_IP_6.5u1d}
-    Prepare Protractor  ${BUILD_7312210_IP}  ${MACOS_HOST_IP}  firefox
+    Log To Console  OVA IP is %{OVA_IP}
+    Prepare Protractor  ${TEST_VC_IP}  ${MACOS_HOST_IP}  firefox
 
     # run protractor
     ${rc}  ${out}=  Run And Return Rc And Output  cd h5c/vic/src/vic-webapp && yarn && npm run e2e -- --specs=e2e/vch-create-wizard/1-basic.e2e-spec.ts
@@ -128,8 +121,8 @@ Cleanup Testbed After Protractor Test Completes
     #${out}=  Run  govc cluster.create -dc=Datacenter Cluster3
     #Should Be Empty  ${out}
 
-    #Log To Console  OVA IP is %{OVA_IP_6.5u1d}
-    #Prepare Protractor  ${BUILD_7312210_IP}  ${WINDOWS_HOST_IP}  chrome
+    #Log To Console  Log To Console  OVA IP is %{OVA_IP}
+    #Prepare Protractor  ${TEST_VC_IP}  ${WINDOWS_HOST_IP}  chrome
 
     # run protractor
     #${rc}  ${out}=  Run And Return Rc And Output  cd h5c/vic/src/vic-webapp && yarn && npm run e2e -- --specs=e2e/vch-create-wizard/1-basic.e2e-spec.ts
@@ -148,8 +141,8 @@ Cleanup Testbed After Protractor Test Completes
     ${out}=  Run  govc cluster.change -dc=Datacenter2 -drs-enabled=true /Datacenter2/host/Cluster
     Should Be Empty  ${out}
 
-    Log To Console  OVA IP is %{OVA_IP_6.5u1d}
-    Prepare Protractor  ${BUILD_7312210_IP}  ${WINDOWS_HOST_IP}  chrome
+    Log To Console  OVA IP is %{OVA_IP}
+    Prepare Protractor  ${TEST_VC_IP}  ${WINDOWS_HOST_IP}  chrome
 
     # run protractor
     ${rc}  ${out}=  Run And Return Rc And Output  cd h5c/vic/src/vic-webapp && yarn && npm run e2e -- --specs=e2e/vch-create-wizard/1-basic.e2e-spec.ts
@@ -165,8 +158,8 @@ Cleanup Testbed After Protractor Test Completes
     ${out}=  Run  govc cluster.create -dc=Datacenter2 Cluster
     ${out}=  Run  govc cluster.change -dc=Datacenter2 -drs-enabled=true /Datacenter2/host/Cluster
 
-    Log To Console  OVA IP is %{OVA_IP_6.5u1d}
-    Prepare Protractor  ${BUILD_7312210_IP}  ${WINDOWS_HOST_IP}  firefox
+    Log To Console  OVA IP is %{OVA_IP}
+    Prepare Protractor  ${TEST_VC_IP}  ${WINDOWS_HOST_IP}  firefox
 
     # run protractor
     ${rc}  ${out}=  Run And Return Rc And Output  cd h5c/vic/src/vic-webapp && yarn && npm run e2e -- --specs=e2e/vch-create-wizard/1-basic.e2e-spec.ts
@@ -182,8 +175,8 @@ Cleanup Testbed After Protractor Test Completes
     ${out}=  Run  govc cluster.create -dc=Datacenter2 Cluster
     ${out}=  Run  govc cluster.change -dc=Datacenter2 -drs-enabled=true /Datacenter2/host/Cluster
 
-    Log To Console  OVA IP is %{OVA_IP_6.5u1d}
-    Prepare Protractor  ${BUILD_7312210_IP}  ${WINDOWS_HOST_IP}  internet explorer
+    Log To Console  OVA IP is %{OVA_IP}
+    Prepare Protractor  ${TEST_VC_IP}  ${WINDOWS_HOST_IP}  internet explorer
 
     # run protractor
     ${rc}  ${out}=  Run And Return Rc And Output  cd h5c/vic/src/vic-webapp && yarn && npm run e2e -- --specs=e2e/vch-create-wizard/1-basic.e2e-spec.ts
@@ -199,8 +192,8 @@ Cleanup Testbed After Protractor Test Completes
     ${out}=  Run  govc cluster.create -dc=Datacenter2 Cluster
     ${out}=  Run  govc cluster.change -dc=Datacenter2 -drs-enabled=true /Datacenter2/host/Cluster
 
-    Log To Console  OVA IP is %{OVA_IP_6.5u1d}
-    Prepare Protractor  ${BUILD_7312210_IP}  ${MACOS_HOST_IP}  chrome
+    Log To Console  OVA IP is %{OVA_IP}
+    Prepare Protractor  ${TEST_VC_IP}  ${MACOS_HOST_IP}  chrome
 
     # run protractor
     ${rc}  ${out}=  Run And Return Rc And Output  cd h5c/vic/src/vic-webapp && yarn && npm run e2e -- --specs=e2e/vch-create-wizard/1-basic.e2e-spec.ts
@@ -216,8 +209,8 @@ Cleanup Testbed After Protractor Test Completes
     ${out}=  Run  govc cluster.create -dc=Datacenter2 Cluster
     ${out}=  Run  govc cluster.change -dc=Datacenter2 -drs-enabled=true /Datacenter2/host/Cluster
 
-    Log To Console  OVA IP is %{OVA_IP_6.5u1d}
-    Prepare Protractor  ${BUILD_7312210_IP}  ${MACOS_HOST_IP}  firefox
+    Log To Console  OVA IP is %{OVA_IP}
+    Prepare Protractor  ${TEST_VC_IP}  ${MACOS_HOST_IP}  firefox
 
     # run protractor
     ${rc}  ${out}=  Run And Return Rc And Output  cd h5c/vic/src/vic-webapp && yarn && npm run e2e -- --specs=e2e/vch-create-wizard/1-basic.e2e-spec.ts

--- a/tests/test-cases/Group1-VCH-Creation-Wizard/1-02-Multi-DVS-VCH-Create.robot
+++ b/tests/test-cases/Group1-VCH-Creation-Wizard/1-02-Multi-DVS-VCH-Create.robot
@@ -48,7 +48,7 @@ Cleanup Testbed After Protractor Test Completes
     Run  govc host.remove -dc=Datacenter -host.ip=%{STANDALONE_ESX1_IP}
 
     # kill nimbus esxi created for this test suite
-    ${out}=  Destroy Testbed  svc.vic-ui-${ESX_NAME}
+    ${out}=  Destroy Testbed  %{NIMBUS_USER}-${ESX_NAME}
 
 Deploy Esxi And Prepare Testbed
     Prepare Testbed For Protractor Tests

--- a/tests/test-cases/Group1-VCH-Creation-Wizard/1-02-Multi-DVS-VCH-Create.robot
+++ b/tests/test-cases/Group1-VCH-Creation-Wizard/1-02-Multi-DVS-VCH-Create.robot
@@ -48,7 +48,7 @@ Cleanup Testbed After Protractor Test Completes
     Run  govc host.remove -dc=Datacenter -host.ip=%{STANDALONE_ESX1_IP}
 
     # kill nimbus esxi created for this test suite
-    ${out}=  Destroy Testbed  %{NIMBUS_USER}-${ESX_NAME}
+    ${out}=  Destroy Testbed  svc.vic-ui-${ESX_NAME}
 
 Deploy Esxi And Prepare Testbed
     Prepare Testbed For Protractor Tests

--- a/tests/test-cases/Group1-VCH-Creation-Wizard/1-02-Multi-DVS-VCH-Create.robot
+++ b/tests/test-cases/Group1-VCH-Creation-Wizard/1-02-Multi-DVS-VCH-Create.robot
@@ -24,6 +24,8 @@ ${OVA_UTIL_ROBOT}  https://github.com/vmware/vic-product/raw/master/tests/resour
 
 *** Keywords ***
 Cleanup Testbed After Protractor Test Completes
+    Delete VC Root CA
+
     # Delete all vic-machine generated artifacts
     Run  rm -rf VCH-0*
 

--- a/tests/test-cases/Group1-VCH-Creation-Wizard/1-02-Multi-DVS-VCH-Create.robot
+++ b/tests/test-cases/Group1-VCH-Creation-Wizard/1-02-Multi-DVS-VCH-Create.robot
@@ -51,9 +51,12 @@ Cleanup Testbed After Protractor Test Completes
     ${out}=  Destroy Testbed  %{NIMBUS_USER}-${ESX_NAME}
 
 Deploy Esxi And Prepare Testbed
+    Prepare Testbed For Protractor Tests
     ${vm_name}  ${vm_ip}=  Deploy ESXi On Nimbus And Get Info  ${ESX_NAME}  5969303
     Set Environment Variable  STANDALONE_ESX1_IP  ${vm_ip}
-    Prepare Testbed For Protractor Tests
+    Set Environment Variable  GOVC_URL  ${TEST_VC_IP}
+    Set Environment Variable  GOVC_USERNAME  ${TEST_VC_USERNAME}
+    Set Environment Variable  GOVC_PASSWORD  ${TEST_VC_PASSWORD}
 
     # Add %{STANDALONE_ESX1_IP} to VC
     Run  govc host.remove -dc=Datacenter -host.ip=%{STANDALONE_ESX1_IP}

--- a/tests/test-cases/Group1-VCH-Creation-Wizard/1-02-Multi-DVS-VCH-Create.robot
+++ b/tests/test-cases/Group1-VCH-Creation-Wizard/1-02-Multi-DVS-VCH-Create.robot
@@ -31,7 +31,7 @@ Cleanup Testbed After Protractor Test Completes
     Run  git reset --hard HEAD 2>&1
 
     # Delete binaries
-    Run  rm -rf vic*.tar.gz ui-nightly-run-bin
+    Run  rm -rf vic*.tar.gz
     Run  rm -rf scripts/plugin-packages/com.vmware.vic-v1*
     Run  rm -rf scripts/vsphere-client-serenity/com.vmware.vic.ui-v1*
 
@@ -47,13 +47,6 @@ Cleanup Testbed After Protractor Test Completes
 
 *** Test Cases ***
 [ Windows 10 - Chrome ] Create a VCH on a Multi Distributed Switches Environment
-    Set Environment Variable  TEST_VCSA_BUILD  7312210
-    Set Environment Variable  TEST_VSPHERE_VER  65
-    Set Environment Variable  VC_FINGERPRINT  ${VC_FINGERPRINT_7312210}
-    Set Global Variable  ${TEST_VC_IP}  ${BUILD_7312210_IP}
-    Set Global Variable  ${TEST_VC_USERNAME}  administrator@vsphere.local
-    Set Global Variable  ${TEST_VC_PASSWORD}  Admin!23
-
     # Add %{TEST_ESX1_IP} to VC
     Run  govc host.remove -dc=Datacenter -host.ip=%{TEST_ESX1_IP}
     ${rc}  ${out}=  Run And Return Rc And Output  govc host.add -dc=Datacenter -hostname %{TEST_ESX1_IP} -username root -password ca*hc0w -noverify

--- a/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
@@ -219,8 +219,10 @@ Run Testcases On Mac
     # remotely run robot test
     ${run_tests_command}=  Catenate
     ...  cd ${remote_vic_root}/tests/test-cases/Group18-VIC-UI 2>&1 &&
-    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} /usr/local/bin/robot -d ${REMOTE_RESULTS_FOLDER} --include anyos --include unixlike --test TestCase-* 18-1-VIC-UI-Installer.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
+    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} /usr/local/bin/robot -d ${REMOTE_RESULTS_FOLDER} --include anyos --include unixlike --test TestCase-* 18-1-VIC-UI-Installer.robot 2>&1
     ${stdout}  ${rc}=  Execute Command  ${run_tests_command}  return_rc=True
+    Create File  ${results_folder}/remote_stdouterr.log  ${stdout}
+    Log To Console  ${stdout}
 
     # Store whether the run was successful
     ${remote_command_successful}=  Run Keyword And Return Status  Should Be Equal As Integers  ${rc}  0
@@ -231,17 +233,13 @@ Run Testcases On Mac
     Execute Command  rm -rf ${REMOTE_RESULTS_FOLDER} ${remote_vic_root}/tests/test-cases/Group18-VIC-UI/*.log 2>&1
     Close Connection
 
-    OperatingSystem.File Should Exist  ${results_folder}/remote_stdouterr.log
-    ${remote_stdouterr}=  OperatingSystem.Get File  ${results_folder}/remote_stdouterr.log
-    Log To Console  ${remote_stdouterr}
-
     # report pass or fail
     Should Be True  ${remote_command_successful}
 
 # Run the test cases above in Windows
 Run Testcases On Windows
     ${results_folder}=  Set Variable  ../../../%{TEST_RESULTS_FOLDER}
-    ${remote_vic_root}=  Set Variable  /cygdrive/c/Users/IEUser/vic-ui
+    ${remote_vic_root}=  Set Variable  /cygdrive/c/Users/Administrator/vic-ui
     ${remote_scratch_folder}=  Set Variable  /tmp/vic-ui-e2e-scratch
     OperatingSystem.Create Directory  ${results_folder}
 
@@ -250,13 +248,10 @@ Run Testcases On Windows
     Execute Command  mkdir -p ${remote_scratch_folder}
     Put File  ../../../testbed-information-%{BUILD_NUMBER}  ${remote_vic_root}/
     Put File  ../../../scripts/plugin-manifest  ${remote_vic_root}/scripts/
-    Put File  ../../../scripts/vCenterForWindows/configs  ${remote_vic_root}/scripts/vCenterForWindows/
-    Put File  ../../../vic-ui-windows.exe  ${remote_vic_root}/
+    Put File  ../../../ui-nightly-run-bin/vic-ui-windows.exe  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_scratch_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
-    Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     Execute Command  rm -rf ${REMOTE_RESULTS_FOLDER}
@@ -273,28 +268,22 @@ Run Testcases On Windows
     # sync tests and configs file
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../tests ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts/vCenterForWindows/configs ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/scripts/vCenterForWindows/ 2>&1
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin/ui/vCenterForWindows/configs ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/scripts/vCenterForWindows/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     # remotely run robot test
     ${ssh_command2}=  Catenate
-    ...  ls -la
-    # ...  cd tests/test-cases/Group18-VIC-UI &&
-    # ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} /cygdrive/c/Python27/Scripts/robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-1-VIC-UI-Installer.robot
-    # ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} /cygdrive/c/Python27/Scripts/robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-1-VIC-UI-Installer.robot > /cygdrive/c${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
-
-    ${stdout}  ${robotscript_rc2}  ${robotscript_stderr}=  Execute Command  ${ssh_command2}  return_rc=True  return_stderr=True
-    Log To Console  returning stdout:  ${stdout}
-    Log To Console  returning stderr: ${robotscript_stderr}
+    ...  cd ${remote_vic_root}/tests/test-cases/Group18-VIC-UI &&
+    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} /cygdrive/c/Python27/Scripts/robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-1-VIC-UI-Installer.robot 2>&1
+    ${stdout}  ${robotscript_rc2}=  Execute Command  ${ssh_command2}  return_rc=True
+    Create File  ${results_folder}/remote_stdouterr.log  ${stdout}
+    Log To Console  ${stdout}
 
     # Store whether the run was successful, print out any error message
     ${did_all_tests_pass}=  Run Keyword And Return Status  Should Be Equal As Integers  ${robotscript_rc2}  0
     Run Keyword Unless  ${did_all_tests_pass}  Log To Console  remote command exited with rc > 0: ${stdout}
 
     # download test results bundle to ../../../%{TEST_RESULTS_FOLDER} and close connection
-    ${rc}  ${out}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${REMOTE_RESULTS_FOLDER}/* ${results_folder} 2>&1
-    Run Keyword Unless  ${rc} == 0  Log  scp failed fetching robot test stdout/stderr log: ${out}  ERROR
-    Should Be Equal As Integers  ${rc}  0
     ${rc}  ${out}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:/cygdrive/c${REMOTE_RESULTS_FOLDER}/* ${results_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log  scp failed fetching output.xml file: ${out}  ERROR
     Should Be Equal As Integers  ${rc}  0
@@ -308,10 +297,6 @@ Run Testcases On Windows
 
     # fix permission issue for files fetched from the remote host
     Run  chmod -R 644 ${results_folder}/*
-
-    OperatingSystem.File Should Exist  ${results_folder}/remote_stdouterr.log
-    ${remote_stdouterr}=  OperatingSystem.Get File  ${results_folder}/remote_stdouterr.log
-    Log To Console  ${remote_stdouterr}
 
     # report pass or fail
     Should Be True  ${did_all_tests_pass}

--- a/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
@@ -246,6 +246,7 @@ Run Testcases On Windows
     # log into Windows host and copy required files
     Open SSH Connection  ${WINDOWS_HOST_IP}  ${WINDOWS_HOST_USER}  ${WINDOWS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
+    Execute Command  mkdir -p ${remote_vic_root}/ui-nightly-run-bin
     Put File  ../../../testbed-information-%{BUILD_NUMBER}  ${remote_vic_root}/
     Put File  ../../../scripts/plugin-manifest  ${remote_vic_root}/scripts/
     Put File  ../../../ui-nightly-run-bin/vic-ui-windows.exe  ${remote_vic_root}/
@@ -268,8 +269,11 @@ Run Testcases On Windows
     # sync tests and configs file
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../tests ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin/ui/vCenterForWindows/configs ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/scripts/vCenterForWindows/ 2>&1
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin/ui ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ui-nightly-run-bin/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
+
+    ${stdout}=  Execute Command  cp -rvf ${remote_vic_root}/ui-nightly-run-bin/ui/* ${remote_vic_root}/scripts/
+    Log To Console  ${stdout}
 
     # remotely run robot test
     ${ssh_command2}=  Catenate

--- a/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
@@ -26,7 +26,6 @@ ${REMOTE_RESULTS_FOLDER}  /tmp/vic-ui-e2e-installer
 *** Keywords ***
 Load Testbed Information And Force Remove Vicui Plugin
     # load nimbus & vch testbed information from testbed-information
-    Load Nimbus Testbed Env
     Force Remove Vicui Plugin
     Set Absolute Script Paths
 

--- a/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
@@ -194,6 +194,8 @@ Run Testcases On Mac
     Put File  ../../../ui-nightly-run-bin/vic-ui-darwin  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${MACOS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${MACOS_HOST_USER}@${MACOS_HOST_IP}:${remote_scratch_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${MACOS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin ${MACOS_HOST_USER}@${MACOS_HOST_IP}:${remote_vic_root} 2>&1
+    Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     # update local repo
     ${update_repo_command}=  Catenate
@@ -204,6 +206,10 @@ Run Testcases On Mac
     ...  git rebase vmware/master
     ${stdout}  ${stderr}  ${rc}=  Execute Command  ${update_repo_command}  return_stderr=True  return_rc=True
     Run Keyword Unless  ${rc} == 0  Log To Console  ${stderr}
+
+    # Sync tests
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${MACOS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../tests ${MACOS_HOST_USER}@${MACOS_HOST_IP}:${remote_vic_root} 2>&1
+    Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     # copy binaries
     ${stdout}  ${stderr}  ${rc}=  Execute Command  cp -rvf ${remote_scratch_folder}/scripts ${remote_vic_root}/  return_stderr=True  return_rc=True
@@ -250,19 +256,29 @@ Run Testcases On Windows
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
+    Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     Execute Command  rm -rf ${REMOTE_RESULTS_FOLDER}
     Execute Command  mkdir -p ${REMOTE_RESULTS_FOLDER}
 
-    # remotely run robot test
+    # sync repo
     ${ssh_command}=  Catenate
     ...  cd ${remote_vic_root} &&
     ...  git remote update &&
     ...  git checkout -f master &&
-    ...  git rebase vmware/master &&
+    ...  git rebase vmware/master
+    ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True
+
+    # sync tests
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../tests ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
+    Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
+
+    # remotely run robot test
+    ${ssh_command2}=  Catenate
     ...  cd tests/test-cases/Group18-VIC-UI &&
     ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-1-VIC-UI-Installer.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
-    ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True
+    ${stdout}  ${robotscript_rc2}=  Execute Command  ${ssh_command2}  return_rc=True
 
     # Store whether the run was successful, print out any error message
     ${did_all_tests_pass}=  Run Keyword And Return Status  Should Be Equal As Integers  ${robotscript_rc}  0

--- a/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
@@ -281,7 +281,7 @@ Run Testcases On Windows
     ${stdout}  ${robotscript_rc2}=  Execute Command  ${ssh_command2}  return_rc=True
 
     # Store whether the run was successful, print out any error message
-    ${did_all_tests_pass}=  Run Keyword And Return Status  Should Be Equal As Integers  ${robotscript_rc}  0
+    ${did_all_tests_pass}=  Run Keyword And Return Status  Should Be Equal As Integers  ${robotscript_rc2}  0
     Run Keyword Unless  ${did_all_tests_pass}  Log To Console  remote command exited with rc > 0: ${stdout}
 
     # download test results bundle to ../../../%{TEST_RESULTS_FOLDER} and close connection

--- a/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
@@ -270,15 +270,22 @@ Run Testcases On Windows
     ...  git rebase vmware/master
     ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True
 
-    # sync tests
+    # sync tests and configs file
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../tests ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
+    Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts/vCenterForWindows/configs ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/scripts/vCenterForWindows/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     # remotely run robot test
     ${ssh_command2}=  Catenate
-    ...  cd tests/test-cases/Group18-VIC-UI &&
-    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-1-VIC-UI-Installer.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
-    ${stdout}  ${robotscript_rc2}=  Execute Command  ${ssh_command2}  return_rc=True
+    ...  ls -la
+    # ...  cd tests/test-cases/Group18-VIC-UI &&
+    # ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} /cygdrive/c/Python27/Scripts/robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-1-VIC-UI-Installer.robot
+    # ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} /cygdrive/c/Python27/Scripts/robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-1-VIC-UI-Installer.robot > /cygdrive/c${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
+
+    ${stdout}  ${robotscript_rc2}  ${robotscript_stderr}=  Execute Command  ${ssh_command2}  return_rc=True  return_stderr=True
+    Log To Console  returning stdout:  ${stdout}
+    Log To Console  returning stderr: ${robotscript_stderr}
 
     # Store whether the run was successful, print out any error message
     ${did_all_tests_pass}=  Run Keyword And Return Status  Should Be Equal As Integers  ${robotscript_rc2}  0

--- a/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
@@ -26,6 +26,7 @@ ${REMOTE_RESULTS_FOLDER}  /tmp/vic-ui-e2e-installer
 *** Keywords ***
 Load Testbed Information And Force Remove Vicui Plugin
     # load nimbus & vch testbed information from testbed-information
+    Load Nimbus Testbed Env  ../../../testbed-information-%{BUILD_NUMBER}
     Force Remove Vicui Plugin
     Set Absolute Script Paths
 

--- a/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
@@ -190,7 +190,7 @@ Run Testcases On Mac
     # log into macOS host and copy required files
     Open SSH Connection  ${MACOS_HOST_IP}  ${MACOS_HOST_USER}  ${MACOS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
-    Put File  testbed-information  ${remote_vic_root}/tests/test-cases/Group18-VIC-UI/  mode=0700
+    Put File  ../../../testbed-information-%{BUILD_NUMBER}  ${remote_vic_root}/  mode=0700
     Put File  ../../../ui-nightly-run-bin/vic-ui-darwin  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${MACOS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${MACOS_HOST_USER}@${MACOS_HOST_IP}:${remote_scratch_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
@@ -213,7 +213,7 @@ Run Testcases On Mac
     # remotely run robot test
     ${run_tests_command}=  Catenate
     ...  cd ${remote_vic_root}/tests/test-cases/Group18-VIC-UI 2>&1 &&
-    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} /usr/local/bin/robot -d ${REMOTE_RESULTS_FOLDER} --include anyos --include unixlike --test TestCase-* 18-1-VIC-UI-Installer.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
+    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} /usr/local/bin/robot -d ${REMOTE_RESULTS_FOLDER} --include anyos --include unixlike --test TestCase-* 18-1-VIC-UI-Installer.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
     ${stdout}  ${rc}=  Execute Command  ${run_tests_command}  return_rc=True
 
     # Store whether the run was successful
@@ -242,9 +242,9 @@ Run Testcases On Windows
     # log into Windows host and copy required files
     Open SSH Connection  ${WINDOWS_HOST_IP}  ${WINDOWS_HOST_USER}  ${WINDOWS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
-    Put File  testbed-information  ${remote_vic_root}/tests/test-cases/Group18-VIC-UI/
+    Put File  ../../../testbed-information-%{BUILD_NUMBER}  ${remote_vic_root}/
     Put File  ../../../scripts/plugin-manifest  ${remote_vic_root}/scripts/
-    Put File  ../../../scripts/vCenterForWindows/configs-7312210  ${remote_vic_root}/scripts/vCenterForWindows/
+    Put File  ../../../scripts/vCenterForWindows/configs  ${remote_vic_root}/scripts/vCenterForWindows/
     Put File  ../../../vic-ui-windows.exe  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_scratch_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
@@ -261,7 +261,7 @@ Run Testcases On Windows
     ...  git checkout -f master &&
     ...  git rebase vmware/master &&
     ...  cd tests/test-cases/Group18-VIC-UI &&
-    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-1-VIC-UI-Installer.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
+    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-1-VIC-UI-Installer.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
     ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True
 
     # Store whether the run was successful, print out any error message

--- a/tests/test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
@@ -26,7 +26,7 @@ ${REMOTE_RESULTS_FOLDER}  /tmp/vic-ui-e2e-uninstaller
 *** Keywords ***
 Load Testbed Information And Force Install Vicui Plugin
     # load nimbus & vch testbed information from testbed-information
-    Load Nimbus Testbed Env
+    Load Nimbus Testbed Env  ../../../testbed-information-%{BUILD_NUMBER}
     Set Absolute Script Paths
     Force Install Vicui Plugin
 

--- a/tests/test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
@@ -202,7 +202,7 @@ Run Testcases On Mac
     # log into macOS host and copy required files
     Open SSH Connection  ${MACOS_HOST_IP}  ${MACOS_HOST_USER}  ${MACOS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
-    Put File  testbed-information  ${remote_vic_root}/tests/test-cases/Group18-VIC-UI/  mode=0700
+    Put File  ../../../testbed-information-%{BUILD_NUMBER}  ${remote_vic_root}/  mode=0700
     Put File  ../../../ui-nightly-run-bin/vic-ui-darwin  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${MACOS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${MACOS_HOST_USER}@${MACOS_HOST_IP}:${remote_scratch_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
@@ -225,7 +225,7 @@ Run Testcases On Mac
     # remotely run robot test
     ${run_tests_command}=  Catenate
     ...  cd ${remote_vic_root}/tests/test-cases/Group18-VIC-UI 2>&1 &&
-    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} /usr/local/bin/robot -d ${REMOTE_RESULTS_FOLDER} --include anyos --include unixlike --test TestCase-* 18-2-VIC-UI-Uninstaller.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
+    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} /usr/local/bin/robot -d ${REMOTE_RESULTS_FOLDER} --include anyos --include unixlike --test TestCase-* 18-2-VIC-UI-Uninstaller.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
     ${stdout}  ${rc}=  Execute Command  ${run_tests_command}  return_rc=True
 
     # Store whether the run was successful
@@ -254,9 +254,9 @@ Run Testcases On Windows
     # log into Windows host and copy required files
     Open SSH Connection  ${WINDOWS_HOST_IP}  ${WINDOWS_HOST_USER}  ${WINDOWS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
-    Put File  testbed-information  ${remote_vic_root}/tests/test-cases/Group18-VIC-UI/
+    Put File  ../../../testbed-information-%{BUILD_NUMBER}  ${remote_vic_root}/
     Put File  ../../../scripts/plugin-manifest  ${remote_vic_root}/scripts/
-    Put File  ../../../scripts/vCenterForWindows/configs-7312210  ${remote_vic_root}/scripts/vCenterForWindows/
+    Put File  ../../../scripts/vCenterForWindows/configs  ${remote_vic_root}/scripts/vCenterForWindows/
     Put File  ../../../vic-ui-windows.exe  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_scratch_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
@@ -271,7 +271,7 @@ Run Testcases On Windows
     ...  git checkout -f master &&
     ...  git rebase vmware/master &&
     ...  cd tests/test-cases/Group18-VIC-UI &&
-    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-2-VIC-UI-Uninstaller.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
+    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-2-VIC-UI-Uninstaller.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
     ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True
 
     # Store whether the run was successful, print out any error message

--- a/tests/test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
@@ -280,8 +280,10 @@ Run Testcases On Windows
     ...  git rebase vmware/master
     ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True
 
-    # sync tests
+    # sync tests and configs file
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../tests ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
+    Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts/vCenterForWindows/configs ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/scripts/vCenterForWindows/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
     
     # remotely run robot test

--- a/tests/test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
@@ -231,8 +231,10 @@ Run Testcases On Mac
     # remotely run robot test
     ${run_tests_command}=  Catenate
     ...  cd ${remote_vic_root}/tests/test-cases/Group18-VIC-UI 2>&1 &&
-    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} /usr/local/bin/robot -d ${REMOTE_RESULTS_FOLDER} --include anyos --include unixlike --test TestCase-* 18-2-VIC-UI-Uninstaller.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
+    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} /usr/local/bin/robot -d ${REMOTE_RESULTS_FOLDER} --include anyos --include unixlike --test TestCase-* 18-2-VIC-UI-Uninstaller.robot 2>&1
     ${stdout}  ${rc}=  Execute Command  ${run_tests_command}  return_rc=True
+    Create File  ${results_folder}/remote_stdouterr.log  ${stdout}
+    Log To Console  ${stdout}
 
     # Store whether the run was successful
     ${remote_command_successful}=  Run Keyword And Return Status  Should Be Equal As Integers  ${rc}  0
@@ -243,17 +245,13 @@ Run Testcases On Mac
     Execute Command  rm -rf ${REMOTE_RESULTS_FOLDER} ${remote_vic_root}/tests/test-cases/Group18-VIC-UI/*.log 2>&1
     Close Connection
 
-    OperatingSystem.File Should Exist  ${results_folder}/remote_stdouterr.log
-    ${remote_stdouterr}=  OperatingSystem.Get File  ${results_folder}/remote_stdouterr.log
-    Log To Console  ${remote_stdouterr}
-
     # report pass or fail
     Should Be True  ${remote_command_successful}
 
 # Run the test cases above in Windows
 Run Testcases On Windows
     ${results_folder}=  Set Variable  ../../../%{TEST_RESULTS_FOLDER}
-    ${remote_vic_root}=  Set Variable  /cygdrive/c/Users/IEUser/vic-ui
+    ${remote_vic_root}=  Set Variable  /cygdrive/c/Users/Administrator/vic-ui
     ${remote_scratch_folder}=  Set Variable  /tmp/vic-ui-e2e-scratch
     OperatingSystem.Create Directory  ${results_folder}
 
@@ -262,11 +260,8 @@ Run Testcases On Windows
     Execute Command  mkdir -p ${remote_scratch_folder}
     Put File  ../../../testbed-information-%{BUILD_NUMBER}  ${remote_vic_root}/
     Put File  ../../../scripts/plugin-manifest  ${remote_vic_root}/scripts/
-    Put File  ../../../scripts/vCenterForWindows/configs  ${remote_vic_root}/scripts/vCenterForWindows/
-    Put File  ../../../vic-ui-windows.exe  ${remote_vic_root}/
+    Put File  ../../../ui-nightly-run-bin/vic-ui-windows.exe  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_scratch_folder} 2>&1
-    Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     Execute Command  rm -rf ${REMOTE_RESULTS_FOLDER}
@@ -283,23 +278,22 @@ Run Testcases On Windows
     # sync tests and configs file
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../tests ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts/vCenterForWindows/configs ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/scripts/vCenterForWindows/ 2>&1
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin/ui/vCenterForWindows/configs ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/scripts/vCenterForWindows/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
     
     # remotely run robot test
     ${ssh_command2}=  Catenate
-    ...  cd tests/test-cases/Group18-VIC-UI &&
-    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-2-VIC-UI-Uninstaller.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
+    ...  cd ${remote_vic_root}/tests/test-cases/Group18-VIC-UI &&
+    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} /cygdrive/c/Python27/Scripts/robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-2-VIC-UI-Uninstaller.robot 2>&1
     ${stdout}  ${robotscript_rc2}=  Execute Command  ${ssh_command2}  return_rc=True
+    Create File  ${results_folder}/remote_stdouterr.log  ${stdout}
+    Log To Console  ${stdout}
 
     # Store whether the run was successful, print out any error message
     ${did_all_tests_pass}=  Run Keyword And Return Status  Should Be Equal As Integers  ${robotscript_rc2}  0
     Run Keyword Unless  ${did_all_tests_pass}  Log To Console  remote command exited with rc > 0: ${stdout}
 
     # download test results bundle to ../../../%{TEST_RESULTS_FOLDER} and close connection
-    ${rc}  ${out}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${REMOTE_RESULTS_FOLDER}/* ${results_folder} 2>&1
-    Run Keyword Unless  ${rc} == 0  Log  scp failed fetching robot test stdout/stderr log: ${out}  ERROR
-    Should Be Equal As Integers  ${rc}  0
     ${rc}  ${out}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:/cygdrive/c${REMOTE_RESULTS_FOLDER}/* ${results_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log  scp failed fetching output.xml file: ${out}  ERROR
     Should Be Equal As Integers  ${rc}  0
@@ -313,10 +307,6 @@ Run Testcases On Windows
 
     # fix permission issue for files fetched from the remote host
     Run  chmod -R 644 ${results_folder}/*
-
-    OperatingSystem.File Should Exist  ${results_folder}/remote_stdouterr.log
-    ${remote_stdouterr}=  OperatingSystem.Get File  ${results_folder}/remote_stdouterr.log
-    Log To Console  ${remote_stdouterr}
 
     # report pass or fail
     Should Be True  ${did_all_tests_pass}

--- a/tests/test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
@@ -206,6 +206,8 @@ Run Testcases On Mac
     Put File  ../../../ui-nightly-run-bin/vic-ui-darwin  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${MACOS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${MACOS_HOST_USER}@${MACOS_HOST_IP}:${remote_scratch_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${MACOS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin ${MACOS_HOST_USER}@${MACOS_HOST_IP}:${remote_vic_root} 2>&1
+    Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     # update local repo
     ${update_repo_command}=  Catenate
@@ -216,6 +218,10 @@ Run Testcases On Mac
     ...  git rebase vmware/master
     ${stdout}  ${stderr}  ${rc}=  Execute Command  ${update_repo_command}  return_stderr=True  return_rc=True
     Run Keyword Unless  ${rc} == 0  Log To Console  ${stderr}
+
+    # Sync tests
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${MACOS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../tests ${MACOS_HOST_USER}@${MACOS_HOST_IP}:${remote_vic_root} 2>&1
+    Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     # copy binaries
     ${stdout}  ${stderr}  ${rc}=  Execute Command  cp -rvf ${remote_scratch_folder}/scripts ${remote_vic_root}/  return_stderr=True  return_rc=True
@@ -260,19 +266,29 @@ Run Testcases On Windows
     Put File  ../../../vic-ui-windows.exe  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_scratch_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
+    Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     Execute Command  rm -rf ${REMOTE_RESULTS_FOLDER}
     Execute Command  mkdir -p ${REMOTE_RESULTS_FOLDER}
 
-    # remotely run robot test
+    # sync repo
     ${ssh_command}=  Catenate
     ...  cd ${remote_vic_root} &&
     ...  git remote update &&
     ...  git checkout -f master &&
-    ...  git rebase vmware/master &&
+    ...  git rebase vmware/master
+    ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True
+
+    # sync tests
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../tests ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
+    Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
+    
+    # remotely run robot test
+    ${ssh_command2}=  Catenate
     ...  cd tests/test-cases/Group18-VIC-UI &&
     ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-2-VIC-UI-Uninstaller.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
-    ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True
+    ${stdout}  ${robotscript_rc2}=  Execute Command  ${ssh_command2}  return_rc=True
 
     # Store whether the run was successful, print out any error message
     ${did_all_tests_pass}=  Run Keyword And Return Status  Should Be Equal As Integers  ${robotscript_rc}  0

--- a/tests/test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
@@ -258,6 +258,7 @@ Run Testcases On Windows
     # log into Windows host and copy required files
     Open SSH Connection  ${WINDOWS_HOST_IP}  ${WINDOWS_HOST_USER}  ${WINDOWS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
+    Execute Command  mkdir -p ${remote_vic_root}/ui-nightly-run-bin
     Put File  ../../../testbed-information-%{BUILD_NUMBER}  ${remote_vic_root}/
     Put File  ../../../scripts/plugin-manifest  ${remote_vic_root}/scripts/
     Put File  ../../../ui-nightly-run-bin/vic-ui-windows.exe  ${remote_vic_root}/
@@ -278,8 +279,11 @@ Run Testcases On Windows
     # sync tests and configs file
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../tests ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin/ui/vCenterForWindows/configs ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/scripts/vCenterForWindows/ 2>&1
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin/ui ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ui-nightly-run-bin/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
+
+    ${stdout}=  Execute Command  cp -rvf ${remote_vic_root}/ui-nightly-run-bin/ui/* ${remote_vic_root}/scripts/
+    Log To Console  ${stdout}
     
     # remotely run robot test
     ${ssh_command2}=  Catenate

--- a/tests/test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
@@ -291,7 +291,7 @@ Run Testcases On Windows
     ${stdout}  ${robotscript_rc2}=  Execute Command  ${ssh_command2}  return_rc=True
 
     # Store whether the run was successful, print out any error message
-    ${did_all_tests_pass}=  Run Keyword And Return Status  Should Be Equal As Integers  ${robotscript_rc}  0
+    ${did_all_tests_pass}=  Run Keyword And Return Status  Should Be Equal As Integers  ${robotscript_rc2}  0
     Run Keyword Unless  ${did_all_tests_pass}  Log To Console  remote command exited with rc > 0: ${stdout}
 
     # download test results bundle to ../../../%{TEST_RESULTS_FOLDER} and close connection

--- a/tests/test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
@@ -302,7 +302,7 @@ Run Testcases On Windows
     ${stdout}  ${robotscript_rc2}=  Execute Command  ${ssh_command2}  return_rc=True
 
     # Store whether the run was successful, print out any error message
-    ${did_all_tests_pass}=  Run Keyword And Return Status  Should Be Equal As Integers  ${robotscript_rc}  0
+    ${did_all_tests_pass}=  Run Keyword And Return Status  Should Be Equal As Integers  ${robotscript_rc2}  0
     Run Keyword Unless  ${did_all_tests_pass}  Log To Console  remote command exited with rc > 0: ${stdout}
 
     # download test results bundle to ../../../%{TEST_RESULTS_FOLDER} and close connection

--- a/tests/test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
@@ -213,7 +213,7 @@ Run Testcases On Mac
     # log into macOS host and copy required files
     Open SSH Connection  ${MACOS_HOST_IP}  ${MACOS_HOST_USER}  ${MACOS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
-    Put File  testbed-information  ${remote_vic_root}/tests/test-cases/Group18-VIC-UI/  mode=0700
+    Put File  ../../../testbed-information-%{BUILD_NUMBER}  ${remote_vic_root}/  mode=0700
     Put File  ../../../ui-nightly-run-bin/vic-ui-darwin  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${MACOS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${MACOS_HOST_USER}@${MACOS_HOST_IP}:${remote_scratch_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
@@ -236,7 +236,7 @@ Run Testcases On Mac
     # remotely run robot test
     ${run_tests_command}=  Catenate
     ...  cd ${remote_vic_root}/tests/test-cases/Group18-VIC-UI 2>&1 &&
-    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} /usr/local/bin/robot -d ${REMOTE_RESULTS_FOLDER} --include anyos --include unixlike --test TestCase-* 18-3-VIC-UI-Upgrader.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
+    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} /usr/local/bin/robot -d ${REMOTE_RESULTS_FOLDER} --include anyos --include unixlike --test TestCase-* 18-3-VIC-UI-Upgrader.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
     ${stdout}  ${rc}=  Execute Command  ${run_tests_command}  return_rc=True
 
     # Store whether the run was successful
@@ -265,9 +265,9 @@ Run Testcases On Windows
     # log into Windows host and copy required files
     Open SSH Connection  ${WINDOWS_HOST_IP}  ${WINDOWS_HOST_USER}  ${WINDOWS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
-    Put File  testbed-information  ${remote_vic_root}/tests/test-cases/Group18-VIC-UI/
+    Put File  ../../../testbed-information-%{BUILD_NUMBER}  ${remote_vic_root}/
     Put File  ../../../scripts/plugin-manifest  ${remote_vic_root}/scripts/
-    Put File  ../../../scripts/vCenterForWindows/configs-7312210  ${remote_vic_root}/scripts/vCenterForWindows/
+    Put File  ../../../scripts/vCenterForWindows/configs  ${remote_vic_root}/scripts/vCenterForWindows/
     Put File  ../../../vic-ui-windows.exe  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_scratch_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
@@ -282,7 +282,7 @@ Run Testcases On Windows
     ...  git checkout -f master &&
     ...  git rebase vmware/master &&
     ...  cd tests/test-cases/Group18-VIC-UI &&
-    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-3-VIC-UI-Upgrader.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
+    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-3-VIC-UI-Upgrader.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
     ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True
 
     # Store whether the run was successful, print out any error message

--- a/tests/test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
@@ -271,6 +271,7 @@ Run Testcases On Windows
     # log into Windows host and copy required files
     Open SSH Connection  ${WINDOWS_HOST_IP}  ${WINDOWS_HOST_USER}  ${WINDOWS_HOST_PASSWORD}
     Execute Command  mkdir -p ${remote_scratch_folder}
+    Execute Command  mkdir -p ${remote_vic_root}/ui-nightly-run-bin
     Put File  ../../../testbed-information-%{BUILD_NUMBER}  ${remote_vic_root}/
     Put File  ../../../scripts/plugin-manifest  ${remote_vic_root}/scripts/
     Put File  ../../../ui-nightly-run-bin/vic-ui-windows.exe  ${remote_vic_root}/
@@ -291,8 +292,11 @@ Run Testcases On Windows
     # sync tests and configs file
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../tests ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin/ui/vCenterForWindows/configs ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/scripts/vCenterForWindows/ 2>&1
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin/ui ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ui-nightly-run-bin/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
+
+    ${stdout}=  Execute Command  cp -rvf ${remote_vic_root}/ui-nightly-run-bin/ui/* ${remote_vic_root}/scripts/
+    Log To Console  ${stdout}
 
     # remotely run robot test
     ${ssh_command2}=  Catenate

--- a/tests/test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
@@ -291,8 +291,10 @@ Run Testcases On Windows
     ...  git rebase vmware/master
     ${stdout}  ${robotscript_rc}=  Execute Command  ${ssh_command}  return_rc=True
 
-    # sync tests
+    # sync tests and configs file
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../tests ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
+    Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts/vCenterForWindows/configs ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/scripts/vCenterForWindows/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     # remotely run robot test

--- a/tests/test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
@@ -26,7 +26,7 @@ ${REMOTE_RESULTS_FOLDER}  /tmp/vic-ui-e2e-upgrader
 *** Keywords ***
 Load Testbed Information And Force Remove Vicui Plugin
     # load nimbus & vch testbed information from testbed-information
-    Load Nimbus Testbed Env
+    Load Nimbus Testbed Env  ../../../testbed-information-%{BUILD_NUMBER}
     Force Remove Vicui Plugin
     Set Absolute Script Paths
 

--- a/tests/test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-3-VIC-UI-Upgrader.robot
@@ -264,7 +264,7 @@ Run Testcases On Mac
 # Run the test cases above in Windows
 Run Testcases On Windows
     ${results_folder}=  Set Variable  ../../../%{TEST_RESULTS_FOLDER}
-    ${remote_vic_root}=  Set Variable  /cygdrive/c/Users/IEUser/vic-ui
+    ${remote_vic_root}=  Set Variable  /cygdrive/c/Users/Administrator/vic-ui
     ${remote_scratch_folder}=  Set Variable  /tmp/vic-ui-e2e-scratch
     OperatingSystem.Create Directory  ${results_folder}
 
@@ -273,11 +273,8 @@ Run Testcases On Windows
     Execute Command  mkdir -p ${remote_scratch_folder}
     Put File  ../../../testbed-information-%{BUILD_NUMBER}  ${remote_vic_root}/
     Put File  ../../../scripts/plugin-manifest  ${remote_vic_root}/scripts/
-    Put File  ../../../scripts/vCenterForWindows/configs  ${remote_vic_root}/scripts/vCenterForWindows/
-    Put File  ../../../vic-ui-windows.exe  ${remote_vic_root}/
+    Put File  ../../../ui-nightly-run-bin/vic-ui-windows.exe  ${remote_vic_root}/
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_scratch_folder} 2>&1
-    Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     Execute Command  rm -rf ${REMOTE_RESULTS_FOLDER}
@@ -294,23 +291,22 @@ Run Testcases On Windows
     # sync tests and configs file
     ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../tests ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../scripts/vCenterForWindows/configs ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/scripts/vCenterForWindows/ 2>&1
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ../../../ui-nightly-run-bin/ui/vCenterForWindows/configs ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${remote_vic_root}/scripts/vCenterForWindows/ 2>&1
     Run Keyword Unless  ${rc} == 0  Log To Console  ${output}
 
     # remotely run robot test
     ${ssh_command2}=  Catenate
-    ...  cd tests/test-cases/Group18-VIC-UI &&
-    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-3-VIC-UI-Upgrader.robot > ${REMOTE_RESULTS_FOLDER}/remote_stdouterr.log 2>&1
+    ...  cd ${remote_vic_root}/tests/test-cases/Group18-VIC-UI &&
+    ...  TEST_VCSA_BUILD=%{TEST_VCSA_BUILD} BUILD_NUMBER=%{BUILD_NUMBER} /cygdrive/c/Python27/Scripts/robot.bat -d ${REMOTE_RESULTS_FOLDER} --include anyos --include windows --test TestCase-* 18-3-VIC-UI-Upgrader.robot 2>&1
     ${stdout}  ${robotscript_rc2}=  Execute Command  ${ssh_command2}  return_rc=True
+    Create File  ${results_folder}/remote_stdouterr.log  ${stdout}
+    Log To Console  ${stdout}
 
     # Store whether the run was successful, print out any error message
     ${did_all_tests_pass}=  Run Keyword And Return Status  Should Be Equal As Integers  ${robotscript_rc2}  0
     Run Keyword Unless  ${did_all_tests_pass}  Log To Console  remote command exited with rc > 0: ${stdout}
 
     # download test results bundle to ../../../%{TEST_RESULTS_FOLDER} and close connection
-    ${rc}  ${out}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:${REMOTE_RESULTS_FOLDER}/* ${results_folder} 2>&1
-    Run Keyword Unless  ${rc} == 0  Log  scp failed fetching robot test stdout/stderr log: ${out}  ERROR
-    Should Be Equal As Integers  ${rc}  0
     ${rc}  ${out}=  Run And Return Rc And Output  sshpass -p "${WINDOWS_HOST_PASSWORD}" scp -o StrictHostKeyChecking\=no -r ${WINDOWS_HOST_USER}@${WINDOWS_HOST_IP}:/cygdrive/c${REMOTE_RESULTS_FOLDER}/* ${results_folder} 2>&1
     Run Keyword Unless  ${rc} == 0  Log  scp failed fetching output.xml file: ${out}  ERROR
     Should Be Equal As Integers  ${rc}  0
@@ -324,10 +320,6 @@ Run Testcases On Windows
 
     # fix permission issue for files fetched from the remote host
     Run  chmod -R 644 ${results_folder}/*
-
-    OperatingSystem.File Should Exist  ${results_folder}/remote_stdouterr.log
-    ${remote_stdouterr}=  OperatingSystem.Get File  ${results_folder}/remote_stdouterr.log
-    Log To Console  ${remote_stdouterr}
 
     # report pass or fail
     Should Be True  ${did_all_tests_pass}

--- a/tests/test-cases/Group18-VIC-UI/18-4-VIC-UI-Plugin-tests.md
+++ b/tests/test-cases/Group18-VIC-UI/18-4-VIC-UI-Plugin-tests.md
@@ -44,30 +44,30 @@ To test functionality of Portlets of the VIC UI plugin in the vSphere Client
     - In an SSH session or macOS Terminal, deploy a VCH using the `vic-machine` binary
       ```
       user $ cd /tmp/vic
-      user $ ./vic-machine-linux create --target tina.eng.vmware.com --user administrator@vsphere.local --password Admin\!23 --name E2E-TEST-VCH --bridge-network bridge --image-store datastore1 --compute-resource Cluster --no-tlsverify --thumbprint 39:4F:92:58:9B:4A:CD:93:F3:73:8F:D2:13:1C:46:DD:4E:92:46:AB
+      user $ ./vic-machine-linux create --target `VC_IP_OR_FQDN` --user administrator@vsphere.local --password Admin\!23 --name E2E-TEST-VCH --bridge-network bridge --image-store datastore1 --compute-resource Cluster --no-tlsverify --thumbprint `THUMBPRINT_OF_THE_VC`
       (take a note of the value of DOCKER_HOST from the output, as it will be used to create a container below)
       ```
-    - Open the browser to navigate to https://tina.eng.vmware.com/vsphere-client
-    - Log in as admin user (administrator@vsphere.local / Admin!23)
+    - Open the browser to navigate to https://`VC_IP_OR_FQDN`/vsphere-client
+    - Log in as admin user
     - Navigate to Administration -> Client Plug-Ins
     - Verify if an entry named “vSphere Integrated Containers-FlexClient" exists
 
   - Test 2.1: Verify if VCH VM Portlet exists
-    - Open the browser to navigate to https://tina.eng.vmware.com/vsphere-client
-    - Log in as admin user (administrator@vsphere.local / Admin!23)
+    - Open the browser to navigate to https://`VC_IP_OR_FQDN`/vsphere-client
+    - Log in as admin user
     - Navigate to the "Hosts and Clusters" page and open the Summary tab of VM "E2E-TEST-VCH"
     - Verify the visibility of portlet "Virtual Container Host"
 
   - Test 2.2: Verify if VCH VM Portlet displays correct information while VM is OFF
-    - Open the browser to navigate to https://tina.eng.vmware.com/vsphere-client
-    - Log in as admin user (administrator@vsphere.local / Admin!23)
+    - Open the browser to navigate to https://`VC_IP_OR_FQDN`/vsphere-client
+    - Log in as admin user
     - Navigate to the "Hosts and Clusters" page and open the Summary tab of VM "E2E-TEST-VCH"
     - Power off the VM
     - Verify in the "Virtual Container Host" portlet if "Docker API endpoint" equals `-`
 
   - Test 2.3: Verify if VCH VM Portlet displays correct information while VM is ON
-    - Open the browser to navigate to https://tina.eng.vmware.com/vsphere-client
-    - Log in as admin user (administrator@vsphere.local / Admin!23)
+    - Open the browser to navigate to https://`VC_IP_OR_FQDN`/vsphere-client
+    - Log in as admin user
     - Navigate to the "Hosts and Clusters" page and open the Summary tab of VM "E2E-TEST-VCH"
     - Power off the VM
     - Verify in the "Virtual Container Host" portlet if "Docker API endpoint" displays the correct connection information
@@ -77,15 +77,15 @@ To test functionality of Portlets of the VIC UI plugin in the vSphere Client
       ```
       user $ docker -H #.#.#.#:2376 --tls run -itd busybox /bin/top
       ```
-    - Open the browser to navigate to https://tina.eng.vmware.com/vsphere-client
-    - Log in as admin user (administrator@vsphere.local / Admin!23)
+    - Open the browser to navigate to https://`VC_IP_OR_FQDN`/vsphere-client
+    - Log in as admin user
     - Navigate to the "Hosts and Clusters" page and open the Summary tab of the container VM that just got created
     - Verify the visibility of portlet "Container"
 
   - Cleanup: Destroy VCH and Container VM
     - In an SSH session or macOS Terminal, delete the VCH and its Container VMs using the `vic-machine` binary
       ```
-      ./vic-machine-linux delete --target tina.eng.vmware.com --user administrator@vsphere.local --password Admin\!23 --name E2E-TEST-VCH --compute-resource Cluster --thumbprint 39:4F:92:58:9B:4A:CD:93:F3:73:8F:D2:13:1C:46:DD:4E:92:46:AB --force
+      ./vic-machine-linux delete --target `VC_IP_OR_FQDN` --user administrator@vsphere.local --name E2E-TEST-VCH --compute-resource Cluster --thumbprint `THUMBPRINT_OF_THE_VC` --force
       ```
 - HTML5 Client plugin
   - Test cases for the H5 Client plugin are basically identical to those of the Flex Client plugin except there are some more cases to test the visibility of the shortcut icon to the vSphere Integrated Containers page in the H5 Client and basic navigation.

--- a/tests/test-cases/Group18-VIC-UI/18-4-VIC-UI-Plugin-tests.md
+++ b/tests/test-cases/Group18-VIC-UI/18-4-VIC-UI-Plugin-tests.md
@@ -44,7 +44,7 @@ To test functionality of Portlets of the VIC UI plugin in the vSphere Client
     - In an SSH session or macOS Terminal, deploy a VCH using the `vic-machine` binary
       ```
       user $ cd /tmp/vic
-      user $ ./vic-machine-linux create --target `VC_IP_OR_FQDN` --user administrator@vsphere.local --password Admin\!23 --name E2E-TEST-VCH --bridge-network bridge --image-store datastore1 --compute-resource Cluster --no-tlsverify --thumbprint `THUMBPRINT_OF_THE_VC`
+      user $ ./vic-machine-linux create --target `VC_IP_OR_FQDN` --user administrator@vsphere.local --password Bl*ckwalnut0 --name E2E-TEST-VCH --bridge-network bridge --image-store datastore1 --compute-resource Cluster --no-tlsverify --thumbprint `THUMBPRINT_OF_THE_VC`
       (take a note of the value of DOCKER_HOST from the output, as it will be used to create a container below)
       ```
     - Open the browser to navigate to https://`VC_IP_OR_FQDN`/vsphere-client

--- a/tests/test-cases/Group18-VIC-UI/18-4-VIC-UI-Plugin-tests.robot
+++ b/tests/test-cases/Group18-VIC-UI/18-4-VIC-UI-Plugin-tests.robot
@@ -120,7 +120,7 @@ Set Up Testbed For NGCTESTS
     Environment Variable Should Be Set  TEST_VC_IP
     ${ESX_HOST_PASSWORD}=  Set Variable  ca*hc0w
     ${TEST_VC_USERNAME}=   Set Variable  administrator@vsphere.local
-    ${TEST_VC_PASSWORD}=   Set Variable  Admin\!23
+    ${TEST_VC_PASSWORD}=   Set Variable  Bl*ckwalnut0
 
     Download And Unzip SUITA
     # set up common testbed provider, host provider and vicenvprovider configurations here according to the content of vicui-common.robot

--- a/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -28,18 +28,12 @@ ${ALL_TESTS_PASSED}            ${TRUE}
 
 *** Keywords ***
 Prepare Testbed
-    # ova url is checked here. should be taken in runtime as a variable
-    # e.g. robot --variable ova_url:https://storage.googleapis.com/vic-product-ova-builds/build-to-test.ova
-    Variable Should Exist  ${ova_url}
-
     ${ts}=  Get Current Date  result_format=epoch  exclude_millis=True
     Set Suite Variable  ${time_start}  ${ts}
     Cleanup Previous Test Logs
     Check Working Dir
     Check Drone
     Check Govc
-    Install VIC Product OVA  6.5u1d  ${BUILD_7312210_IP}  %{OVA_ESX_IP_VC65U1D}  %{OVA_ESX_DATASTORE_VC65U1D}
-    Get Vic Engine Binaries
     Setup Test Matrix
 
 Check Working Dir
@@ -314,7 +308,7 @@ Cleanup Testbed
     Terminate All Processes  kill=True
 
     # Delete all transient and sensitive information
-    Run  rm -rf .drone.local.tests.yml testbed-information tests/test-cases/Group18-VIC-UI/testbed-information /tmp/sdk/ >/dev/null 2>&1
+    Run  rm -rf .drone.local.tests.yml testbed-information /tmp/sdk/ >/dev/null 2>&1
     Run  rm -rf Kickoff-Tests* VCH-0*
 
     # Revert some modified local files
@@ -322,7 +316,6 @@ Cleanup Testbed
 
     # Delete binaries
     Run  rm -rf vicui-test-report-*.zip
-    Run  rm -rf ${LATEST_VIC_ENGINE_TARBALL}
     Run  rm -rf tests/test-cases/Group18-VIC-UI/*VCH-0*
     Run  rm -rf scripts/plugin-packages/com.vmware.vic-v1*
     Run  rm -rf scripts/vsphere-client-serenity/com.vmware.vic.ui-v1*

--- a/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -55,7 +55,6 @@ Check Drone
     Log  Checking Drone version...
     Log  return code: ${rc}, output: ${drone_ver}  DEBUG
     Run Keyword If  ${rc} > ${0}  Fatal Error  Drone is required to run tests!
-    Run Keyword If  '0.5.0' not in '${drone_ver}'  Fatal Error  Drone 0.5.0 is required to run tests!
 
 Check Govc
     ${rc}=  Run And Return Rc  govc
@@ -152,13 +151,15 @@ Setup Test Matrix
 
 Get Testbed Information
     Set Environment Variable  GOVC_INSECURE  1
-    Log To Console  Testbed setup is in progress. See setup-testbed.log for detailed logs.
-    ${results}=  Run Process  bash  -c  robot --exclude presetup -C ansi tests/test-cases/Group18-VIC-UI/setup-testbed.robot > tests/test-cases/Group18-VIC-UI/setup-testbed.log 2>&1
-    Run Keyword If  ${results.rc} == 0  Log To Console  Testbed setup done
-    ${testbed-setup-log}=  OperatingSystem.Get File  tests/test-cases/Group18-VIC-UI/setup-testbed.log
-    Run Keyword Unless  ${results.rc} == 0  Fatal Error  Failed to fetch testbed information! See error below:\n${testbed-setup-log}
-    Load Nimbus Testbed Env
-    Move File  testbed-information  tests/test-cases/Group18-VIC-UI/testbed-information
+    ${file}=  Evaluate  'testbed-information-%{BUILD_NUMBER}'
+    Load Nimbus Testbed Env  ${file}
+    Move File  ${file}  tests/test-cases/Group18-VIC-UI/${file}
+    # Log To Console  Testbed setup is in progress. See setup-testbed.log for detailed logs.
+    # ${results}=  Run Process  bash  -c  robot --exclude presetup -C ansi tests/test-cases/Group18-VIC-UI/setup-testbed.robot > tests/test-cases/Group18-VIC-UI/setup-testbed.log 2>&1
+    # Run Keyword If  ${results.rc} == 0  Log To Console  Testbed setup done
+    # ${testbed-setup-log}=  OperatingSystem.Get File  tests/test-cases/Group18-VIC-UI/setup-testbed.log
+    # Run Keyword Unless  ${results.rc} == 0  Fatal Error  Failed to fetch testbed information! See error below:\n${testbed-setup-log}
+    # Load Nimbus Testbed Env
 
 Get Integration Container Id
     ${rc}  ${out}=  Run And Return Rc And Output  docker ps --filter status=running --filter ancestor=gcr.io/eminent-nation-87317/vic-integration-test:1.33 -l --format={{.ID}}
@@ -214,7 +215,7 @@ Run Script Test With Config
     Should Be Equal As Integers  ${rc}  0
 
     # run drone
-    ${drone-exec-string}=  Set Variable  drone exec --timeout \"1h0m0s\" --timeout.inactivity \"1h0m0s\" --repo.trusted .drone.local.tests.yml
+    ${drone-exec-string}=  Set Variable  drone exec --timeout \"1h0m0s\" .drone.local.tests.yml
     ${pid}=  Start Process  bash  -c  ${drone-exec-string}  stdout=${test_results_folder}/stdout.log  stderr=STDOUT
     ${docker-ps}=  Wait Until Keyword Succeeds  30x  5s  Get Integration Container Id
     Log To Console  Drone worker \@ ${docker-ps}
@@ -282,7 +283,7 @@ Run Plugin Test With Config
     Set To Dictionary  ${PLUGIN_TEST_RESULTS_DICT}  ${dict_key}  \[ FAILED \]\tH5 Client plugin test - Portlets / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os} / ${selenium_browser_normalized}
 
     # run drone
-    ${drone-exec-string}=  Set Variable  drone exec --timeout \"1h0m0s\" --timeout.inactivity \"1h0m0s\" --repo.trusted .drone.local.tests.yml
+    ${drone-exec-string}=  Set Variable  drone exec --timeout \"1h0m0s\" .drone.local.tests.yml
     ${pid}=  Start Process  bash  -c  ${drone-exec-string}  stdout=${test_results_folder}/stdout.log  stderr=STDOUT
     ${docker-ps}=  Wait Until Keyword Succeeds  30x  5s  Get Integration Container Id
     Log To Console  Drone worker \@ ${docker-ps}

--- a/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -357,19 +357,19 @@ Launch Installer Tests
     :FOR  ${config}  IN  @{INSTALLER_TEST_MATRIX}
     \    Run Script Test With Config  ${config}  Installer Test  18-1-VIC-UI-Installer  ${INSTALLER_TEST_RESULTS_DICT}
     \    ${is_skipped}=  Run Keyword And Return Status  List Should Contain Value  ${SKIP_TEST_MATRIX}  Installer Test,${config}
-    \    Run Keyword Unless  ${is_skipped}  Uninstall VCH  ${TRUE}
 
 Launch Uninstaller Tests
     :FOR  ${config}  IN  @{UNINSTALLER_TEST_MATRIX}
     \    Run Script Test With Config  ${config}  Uninstaller Test  18-2-VIC-UI-Uninstaller  ${UNINSTALLER_TEST_RESULTS_DICT}
     \    ${is_skipped}=  Run Keyword And Return Status  List Should Contain Value  ${SKIP_TEST_MATRIX}  Uninstaller Test,${config}
-    \    Run Keyword Unless  ${is_skipped}  Uninstall VCH  ${TRUE}
 
 Launch Upgrader Tests
     :FOR  ${config}  IN  @{UPGRADER_TEST_MATRIX}
     \    Run Script Test With Config  ${config}  Upgrader Test  18-3-VIC-UI-Upgrader  ${UPGRADER_TEST_RESULTS_DICT}
     \    ${is_skipped}=  Run Keyword And Return Status  List Should Contain Value  ${SKIP_TEST_MATRIX}  Upgrader Test,${config}
-    \    Run Keyword Unless  ${is_skipped}  Uninstall VCH  ${TRUE}
+
+Cleanup VCH
+    Uninstall VCH
 
 # All H5 Client plugin tests are now migrated to Protractor
 # Launch Plugin Tests

--- a/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -214,7 +214,7 @@ Run Script Test With Config
     Should Be Equal As Integers  ${rc}  0
 
     # run drone
-    ${drone-exec-string}=  Set Variable  drone exec --local --timeout \"1h0m0s\" .drone.local.tests.yml
+    ${drone-exec-string}=  Set Variable  drone exec --timeout \"1h0m0s\" --timeout.inactivity \"1h0m0s\" --repo.trusted .drone.local.tests.yml
     ${pid}=  Start Process  bash  -c  ${drone-exec-string}  stdout=${test_results_folder}/stdout.log  stderr=STDOUT
     ${docker-ps}=  Wait Until Keyword Succeeds  30x  5s  Get Integration Container Id
     Log To Console  Drone worker \@ ${docker-ps}
@@ -282,7 +282,7 @@ Run Plugin Test With Config
     Set To Dictionary  ${PLUGIN_TEST_RESULTS_DICT}  ${dict_key}  \[ FAILED \]\tH5 Client plugin test - Portlets / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os} / ${selenium_browser_normalized}
 
     # run drone
-    ${drone-exec-string}=  Set Variable  drone exec --local --timeout \"1h0m0s\" .drone.local.tests.yml
+    ${drone-exec-string}=  Set Variable  drone exec --timeout \"1h0m0s\" --timeout.inactivity \"1h0m0s\" --repo.trusted .drone.local.tests.yml
     ${pid}=  Start Process  bash  -c  ${drone-exec-string}  stdout=${test_results_folder}/stdout.log  stderr=STDOUT
     ${docker-ps}=  Wait Until Keyword Succeeds  30x  5s  Get Integration Container Id
     Log To Console  Drone worker \@ ${docker-ps}

--- a/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -187,6 +187,7 @@ Run Script Test With Config
     ${test_results_folder}=  Set Variable  ui-test-results/${test_name}-${dict_key}
     ${sed-replace-command}=  Catenate
     ...  sed -e "s/\#TEST_VSPHERE_VER/${vc_version}/g"
+    ...  -e "s|#BUILD_NUMBER|%{BUILD_NUMBER}|g"
     ...  -e "s|\#TEST_VCSA_BUILD|${vc_build}|g"
     ...  -e "s|\#TEST_OS|${os}|g"
     ...  -e "s|\#TEST_RESULTS_FOLDER|${test_results_folder}|g"

--- a/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -153,7 +153,6 @@ Get Testbed Information
     Set Environment Variable  GOVC_INSECURE  1
     ${file}=  Evaluate  'testbed-information-%{BUILD_NUMBER}'
     Load Nimbus Testbed Env  ${file}
-    Move File  ${file}  tests/test-cases/Group18-VIC-UI/${file}
     # Log To Console  Testbed setup is in progress. See setup-testbed.log for detailed logs.
     # ${results}=  Run Process  bash  -c  robot --exclude presetup -C ansi tests/test-cases/Group18-VIC-UI/setup-testbed.robot > tests/test-cases/Group18-VIC-UI/setup-testbed.log 2>&1
     # Run Keyword If  ${results.rc} == 0  Log To Console  Testbed setup done
@@ -215,7 +214,7 @@ Run Script Test With Config
     Should Be Equal As Integers  ${rc}  0
 
     # run drone
-    ${drone-exec-string}=  Set Variable  drone exec --timeout \"1h0m0s\" .drone.local.tests.yml
+    ${drone-exec-string}=  Set Variable  drone exec --local --timeout \"1h0m0s\" .drone.local.tests.yml
     ${pid}=  Start Process  bash  -c  ${drone-exec-string}  stdout=${test_results_folder}/stdout.log  stderr=STDOUT
     ${docker-ps}=  Wait Until Keyword Succeeds  30x  5s  Get Integration Container Id
     Log To Console  Drone worker \@ ${docker-ps}
@@ -283,7 +282,7 @@ Run Plugin Test With Config
     Set To Dictionary  ${PLUGIN_TEST_RESULTS_DICT}  ${dict_key}  \[ FAILED \]\tH5 Client plugin test - Portlets / VC${vc_version} / ESX build ${esx_build} / VC build ${vc_build} / ${os} / ${selenium_browser_normalized}
 
     # run drone
-    ${drone-exec-string}=  Set Variable  drone exec --timeout \"1h0m0s\" .drone.local.tests.yml
+    ${drone-exec-string}=  Set Variable  drone exec --local --timeout \"1h0m0s\" .drone.local.tests.yml
     ${pid}=  Start Process  bash  -c  ${drone-exec-string}  stdout=${test_results_folder}/stdout.log  stderr=STDOUT
     ${docker-ps}=  Wait Until Keyword Succeeds  30x  5s  Get Integration Container Id
     Log To Console  Drone worker \@ ${docker-ps}

--- a/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -98,35 +98,35 @@ Setup Test Matrix
     # skip matrix
     @{skip_test_config_matrix}=  Create List
     # There's currently a version clash between the Selenium standalone binary and HSUIA project
-    Append To List  ${skip_test_config_matrix}  65,5310538,7312210,Windows,Firefox,Firefox
+    Append To List  ${skip_test_config_matrix}  65,5969303,7515524,Windows,Firefox,Firefox
     # There's a H5C bug in IE11 that appears only when automatically tested
-    Append To List  ${skip_test_config_matrix}  65,5310538,7312210,Windows,IExplorer,IE11
+    Append To List  ${skip_test_config_matrix}  65,5969303,7515524,Windows,IExplorer,IE11
     Set Global Variable  ${SKIP_TEST_MATRIX}  ${skip_test_config_matrix}
 
     # installer test matrix
     @{installer_test_config_matrix}=  Create List
     &{installer_test_results_dict}=  Create Dictionary
-    Append To List  ${installer_test_config_matrix}  65,5310538,7312210,Ubuntu
-    Append To List  ${installer_test_config_matrix}  65,5310538,7312210,Mac
-    Append To List  ${installer_test_config_matrix}  65,5310538,7312210,Windows
+    Append To List  ${installer_test_config_matrix}  65,5969303,7515524,Ubuntu
+    Append To List  ${installer_test_config_matrix}  65,5969303,7515524,Mac
+    Append To List  ${installer_test_config_matrix}  65,5969303,7515524,Windows
     Set Global Variable  ${INSTALLER_TEST_MATRIX}        ${installer_test_config_matrix}
     Set Global Variable  ${INSTALLER_TEST_RESULTS_DICT}  ${installer_test_results_dict}
 
     # uninstaller test matrix
     @{uninstaller_test_config_matrix}=  Create List
     &{uninstaller_test_results_dict}=  Create Dictionary
-    Append To List  ${uninstaller_test_config_matrix}  65,5310538,7312210,Ubuntu
-    Append To List  ${uninstaller_test_config_matrix}  65,5310538,7312210,Mac
-    Append To List  ${uninstaller_test_config_matrix}  65,5310538,7312210,Windows
+    Append To List  ${uninstaller_test_config_matrix}  65,5969303,7515524,Ubuntu
+    Append To List  ${uninstaller_test_config_matrix}  65,5969303,7515524,Mac
+    Append To List  ${uninstaller_test_config_matrix}  65,5969303,7515524,Windows
     Set Global Variable  ${UNINSTALLER_TEST_MATRIX}        ${uninstaller_test_config_matrix}
     Set Global Variable  ${UNINSTALLER_TEST_RESULTS_DICT}  ${uninstaller_test_results_dict}
 
     # upgrader test matrix
     @{upgrader_test_config_matrix}=  Create List
     &{upgrader_test_results_dict}=  Create Dictionary
-    Append To List  ${upgrader_test_config_matrix}  65,5310538,7312210,Ubuntu
-    Append To List  ${upgrader_test_config_matrix}  65,5310538,7312210,Mac
-    Append To List  ${upgrader_test_config_matrix}  65,5310538,7312210,Windows
+    Append To List  ${upgrader_test_config_matrix}  65,5969303,7515524,Ubuntu
+    Append To List  ${upgrader_test_config_matrix}  65,5969303,7515524,Mac
+    Append To List  ${upgrader_test_config_matrix}  65,5969303,7515524,Windows
     Set Global Variable  ${UPGRADER_TEST_MATRIX}        ${upgrader_test_config_matrix}
     Set Global Variable  ${UPGRADER_TEST_RESULTS_DICT}  ${upgrader_test_results_dict}
 
@@ -135,11 +135,11 @@ Setup Test Matrix
     &{plugin_test_results_dict}=  Create Dictionary
     # vSphere H5C and Flex Client are not supported  on Linux
     # https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.upgrade.doc/GUID-F6D456D7-C559-439D-8F34-4FCF533B7B42.html
-    Append To List  ${plugin_test_config_matrix}  65,5310538,7312210,Mac,Chrome,Chrome
-    Append To List  ${plugin_test_config_matrix}  65,5310538,7312210,Mac,Firefox,Firefox
-    Append To List  ${plugin_test_config_matrix}  65,5310538,7312210,Windows,Chrome,Chrome
-    Append To List  ${plugin_test_config_matrix}  65,5310538,7312210,Windows,Firefox,Firefox
-    Append To List  ${plugin_test_config_matrix}  65,5310538,7312210,Windows,IExplorer,IE11
+    Append To List  ${plugin_test_config_matrix}  65,5969303,7515524,Mac,Chrome,Chrome
+    Append To List  ${plugin_test_config_matrix}  65,5969303,7515524,Mac,Firefox,Firefox
+    Append To List  ${plugin_test_config_matrix}  65,5969303,7515524,Windows,Chrome,Chrome
+    Append To List  ${plugin_test_config_matrix}  65,5969303,7515524,Windows,Firefox,Firefox
+    Append To List  ${plugin_test_config_matrix}  65,5969303,7515524,Windows,IExplorer,IE11
     Set Global Variable  ${PLUGIN_TEST_MATRIX}        ${plugin_test_config_matrix}
     Set Global Variable  ${PLUGIN_TEST_RESULTS_DICT}  ${plugin_test_results_dict}
 

--- a/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -117,13 +117,13 @@ Deploy VICUI Testbed
     ...  TEST_VC_IP=${vc_fqdn}
     ...  TEST_URL_ARRAY=${vc_fqdn}
     ...  TEST_USERNAME=Administrator@vsphere.local
-    ...  TEST_PASSWORD=Admin\!23
+    ...  TEST_PASSWORD=Bl*ckwalnut0
     ...  TEST_DATASTORE=datastore1
     ...  EXTERNAL_NETWORK=vm-network
     ...  TEST_TIMEOUT=30m
     ...  GOVC_INSECURE=1
     ...  GOVC_USERNAME=Administrator@vsphere.local
-    ...  GOVC_PASSWORD=Admin\!23
+    ...  GOVC_PASSWORD=Bl*ckwalnut0
     ...  GOVC_URL=${vc_fqdn}\n
 
     Create File  testbed-information-%{BUILD_NUMBER}  ${testbed-information-content}

--- a/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -59,7 +59,7 @@ Prepare VIC UI Testbed
     :FOR  ${esxi_name}  IN  @{esxi_names}
     \  ${esxi_ip}=  Get IP  ${esxi_name}
     \  &{vm}=  Create Dictionary
-    \  Set To Dictionary  ${vm}  name  svc.vic-ui-${esxi_name}
+    \  Set To Dictionary  ${vm}  name  %{NIMBUS_USER}-${esxi_name}
     \  Set To Dictionary  ${vm}  ip  ${esxi_ip}
     \  Set To Dictionary  ${vm}  build  ${esxbuild}
     \  ${idx}=  Get Index from List  ${esxi_names}  ${esxi_name}
@@ -70,7 +70,7 @@ Prepare VIC UI Testbed
     \  Set Environment Variable  GOVC_URL  root:@${esxi_ip}
     \  ${out}=  Run  govc host.account.update -id root -password e2eFunctionalTest
     \  Should Be Empty  ${out}
-    \  Log To Console  Successfully deployed svc.vic-ui-${esxi_name}. IP: ${esxi_ip}
+    \  Log To Console  Successfully deployed %{NIMBUS_USER}-${esxi_name}. IP: ${esxi_ip}
     Close Connection
 
     Log To Console  \nESXi deployment completed

--- a/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -46,6 +46,19 @@ Deploy Esx
 
     [Return]  %{NIMBUS_USER}-${name}  ${esx1-ip}
 
+Deploy ESXi Server On Nimbus Async
+    [Arguments]  ${name}  ${build}=None
+    Log To Console  \nDeploying Nimbus ESXi server: ${name}
+    ${out}=  Run Secret SSHPASS command  %{NIMBUS_USER}  '%{NIMBUS_PASSWORD}'  'nimbus-esxdeploy ${name} --disk\=50000000 --memory\=8192 --lease=1 --nics 2 ${build}'
+    [Return]  ${out}
+
+Deploy VC On Nimbus Async
+    [Arguments]  ${name}  ${build}
+    Log To Console  \nDeploying Nimbus VC server: ${name}
+    ${cmd}=  Evaluate  'nimbus-vcvadeploy --lease\=1 --useQaNgc --vcvaBuild ${build} ${name}'
+    ${out}=  Start Process  sshpass -p '%{NIMBUS_PASSWORD}' ssh -o StrictHostKeyChecking\=no %{NIMBUS_USER}@%{NIMBUS_GW} ${cmd}  shell=True
+    [Return]  ${out}
+
 Deploy Vcsa
     [Arguments]  ${name}  ${build}  ${esxi_list}  ${logfile}=None
     Open SSH Connection  %{NIMBUS_GW}  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  retry_interval=30 sec

--- a/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -182,8 +182,33 @@ Deploy VICUI Testbed
     Set To Dictionary  ${testbed_config}  vc_build  7515524
 
     ${start_time}=  Get Time  epoch
-    ${esxis}  ${vc}=  Prepare VIC UI Testbed  ${testbed_config}
+    # ${esxis}  ${vc}=  Prepare VIC UI Testbed  ${testbed_config}
+    # ${vc_ip}=  Get From Dictionary  ${vc}  ip
+    
+    #####
+    ${esxis}=  Create List
+    &{vc}=  Create Dictionary
+    &{esx}=  Create Dictionary
+    Set To Dictionary  ${esx}  name  kjosh-E2E-4628-ESX-5969303-1
+    Set To Dictionary  ${esx}  ip  10.160.54.122
+    Set To Dictionary  ${esx}  build  5969303
+    Append To List  ${esxis}  ${esx}
+    &{esx}=  Create Dictionary
+    Set To Dictionary  ${esx}  name  kjosh-E2E-4628-ESX-5969303-2
+    Set To Dictionary  ${esx}  ip  10.160.55.124
+    Set To Dictionary  ${esx}  build  5969303
+    Append To List  ${esxis}  ${esx}
+    &{esx}=  Create Dictionary
+    Set To Dictionary  ${esx}  name  kjosh-E2E-4628-ESX-5969303-3
+    Set To Dictionary  ${esx}  ip  10.193.50.135
+    Set To Dictionary  ${esx}  build  5969303
+    Append To List  ${esxis}  ${esx}
+    Set To Dictionary  ${vc}  name  kjosh-E2E-4628-VC-7515524
+    Set To Dictionary  ${vc}  ip  10.161.234.113
+    Set To Dictionary  ${vc}  build  7515524
     ${vc_ip}=  Get From Dictionary  ${vc}  ip
+    #####
+
     ${end_time}=  Get Time  epoch
     ${elapsed_time}=  Evaluate  ${end_time} - ${start_time}
     Log To Console  \nTook ${elapsed_time} seconds to deploy testbed VMs\n

--- a/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -168,28 +168,8 @@ Deploy VICUI Testbed
     Set To Dictionary  ${testbed_config}  esx_build  5969303
     Set To Dictionary  ${testbed_config}  vc_build  7515524
 
-    # ${esxis}  ${vc}=  Prepare VIC UI Testbed  ${testbed_config}
-    # ${vc_ip}=  Get From Dictionary  ${vc}  ip
-
-    ## TODO: delete the debugging code
-    @{esxis}=  Create List
-    &{esxi}=  Create Dictionary
-    Set To Dictionary  ${esxi}  name  kjosh-E2E-6135-ESX-5969303-1
-    Set To Dictionary  ${esxi}  ip  10.192.189.88
-    Set To Dictionary  ${esxi}  build  5969303
-    Append To List  ${esxis}  ${esxi}
-    &{esxi}=  Create Dictionary
-    Set To Dictionary  ${esxi}  name  kjosh-E2E-6135-ESX-5969303-2
-    Set To Dictionary  ${esxi}  ip  10.192.48.180
-    Set To Dictionary  ${esxi}  build  5969303
-    Append To List  ${esxis}  ${esxi}
-    Set To Dictionary  ${esxi}  name  kjosh-E2E-6135-ESX-5969303-3
-    Set To Dictionary  ${esxi}  ip  10.161.0.163
-    Set To Dictionary  ${esxi}  build  5969303
-    Append To List  ${esxis}  ${esxi}
-
-    ${vc_ip}=  Set Variable  10.193.13.43
-    ##
+    ${esxis}  ${vc}=  Prepare VIC UI Testbed  ${testbed_config}
+    ${vc_ip}=  Get From Dictionary  ${vc}  ip
 
     Set Global Variable  ${ESXIs}  ${esxis}
     Set Global Variable  ${VCIP}  ${vc_ip}

--- a/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -164,7 +164,7 @@ Deploy VICUI Testbed
 
     &{testbed_config}=  Create Dictionary
 
-    Set To Dictionary  ${testbed_config}  esx_num  2
+    Set To Dictionary  ${testbed_config}  esx_num  3
     Set To Dictionary  ${testbed_config}  esx_build  5969303
     Set To Dictionary  ${testbed_config}  vc_build  7515524
 
@@ -189,8 +189,11 @@ Deploy VICUI Testbed
     Append To List  ${esxis}  ${esxi}
 
     ${vc_ip}=  Set Variable  10.193.13.43
-
     ##
+
+    Set Global Variable  ${ESXIs}  ${esxis}
+    Set Global Variable  ${VCIP}  ${vc_ip}
+
     ${testbed-information-content}=  Catenate  SEPARATOR=\n
     ...  TEST_VSPHERE_VER=65
     ...  TEST_VC_IP=${vc_ip}
@@ -206,6 +209,13 @@ Deploy VICUI Testbed
     ...  GOVC_URL=${vc_ip}\n
 
     Create File  testbed-information-%{BUILD_NUMBER}  ${testbed-information-content}
+
+Deploy Product OVA
+    ${esxi_ova}=  Get From List  ${ESXIs}  2
+    ${ip}=  Get From Dictionary  ${esxi_ova}  ip
+
+    Install VIC Product OVA  ${VCIP}  ${ip}  datastore1 (2)
+    Get Vic Engine Binaries
 
 Deploy VCH
     ${file}=  Evaluate  'testbed-information-%{BUILD_NUMBER}'

--- a/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -85,8 +85,10 @@ Configure Vcsa
     ${out}=  Run  govc dvs.create -dc=Datacenter test-ds
     Should Contain  ${out}  OK
 
-    # make three port groups
-    Log To Console  Create three new distributed switch port groups for management and vm network traffic
+    # make four port groups
+    Log To Console  Create four new distributed switch port groups for management and vm network traffic
+    ${out}=  Run  govc dvs.portgroup.add -nports 12 -dc=Datacenter -dvs=test-ds bridge
+    Should Contain  ${out}  OK
     ${out}=  Run  govc dvs.portgroup.add -nports 12 -dc=Datacenter -dvs=test-ds management
     Should Contain  ${out}  OK
     ${out}=  Run  govc dvs.portgroup.add -nports 12 -dc=Datacenter -dvs=test-ds vm-network

--- a/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -182,32 +182,8 @@ Deploy VICUI Testbed
     Set To Dictionary  ${testbed_config}  vc_build  7515524
 
     ${start_time}=  Get Time  epoch
-    # ${esxis}  ${vc}=  Prepare VIC UI Testbed  ${testbed_config}
-    # ${vc_ip}=  Get From Dictionary  ${vc}  ip
-    
-    #####
-    ${esxis}=  Create List
-    &{vc}=  Create Dictionary
-    &{esx}=  Create Dictionary
-    Set To Dictionary  ${esx}  name  kjosh-E2E-4628-ESX-5969303-1
-    Set To Dictionary  ${esx}  ip  10.160.54.122
-    Set To Dictionary  ${esx}  build  5969303
-    Append To List  ${esxis}  ${esx}
-    &{esx}=  Create Dictionary
-    Set To Dictionary  ${esx}  name  kjosh-E2E-4628-ESX-5969303-2
-    Set To Dictionary  ${esx}  ip  10.160.55.124
-    Set To Dictionary  ${esx}  build  5969303
-    Append To List  ${esxis}  ${esx}
-    &{esx}=  Create Dictionary
-    Set To Dictionary  ${esx}  name  kjosh-E2E-4628-ESX-5969303-3
-    Set To Dictionary  ${esx}  ip  10.193.50.135
-    Set To Dictionary  ${esx}  build  5969303
-    Append To List  ${esxis}  ${esx}
-    Set To Dictionary  ${vc}  name  kjosh-E2E-4628-VC-7515524
-    Set To Dictionary  ${vc}  ip  10.161.234.113
-    Set To Dictionary  ${vc}  build  7515524
+    ${esxis}  ${vc}=  Prepare VIC UI Testbed  ${testbed_config}
     ${vc_ip}=  Get From Dictionary  ${vc}  ip
-    #####
 
     ${end_time}=  Get Time  epoch
     ${elapsed_time}=  Evaluate  ${end_time} - ${start_time}
@@ -237,6 +213,8 @@ Deploy Product OVA
     ${ip}=  Get From Dictionary  ${esxi_ova}  ip
 
     Install VIC Product OVA  ${VCIP}  ${ip}  datastore1 (2)
+    ${ova_ip}=  Evaluate  '%{OVA_IP_%{BUILD_NUMBER}}'
+    Append To File  testbed-information-%{BUILD_NUMBER}  OVA_IP=${ova_ip}\n
     Get Vic Engine Binaries
 
 Deploy VCH

--- a/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -59,7 +59,7 @@ Prepare VIC UI Testbed
     :FOR  ${esxi_name}  IN  @{esxi_names}
     \  ${esxi_ip}=  Get IP  ${esxi_name}
     \  &{vm}=  Create Dictionary
-    \  Set To Dictionary  ${vm}  name  %{NIMBUS_USER}-${esxi_name}
+    \  Set To Dictionary  ${vm}  name  svc.vic-ui-${esxi_name}
     \  Set To Dictionary  ${vm}  ip  ${esxi_ip}
     \  Set To Dictionary  ${vm}  build  ${esxbuild}
     \  ${idx}=  Get Index from List  ${esxi_names}  ${esxi_name}
@@ -70,7 +70,7 @@ Prepare VIC UI Testbed
     \  Set Environment Variable  GOVC_URL  root:@${esxi_ip}
     \  ${out}=  Run  govc host.account.update -id root -password e2eFunctionalTest
     \  Should Be Empty  ${out}
-    \  Log To Console  Successfully deployed %{NIMBUS_USER}-${esxi_name}. IP: ${esxi_ip}
+    \  Log To Console  Successfully deployed svc.vic-ui-${esxi_name}. IP: ${esxi_ip}
     Close Connection
 
     Log To Console  \nESXi deployment completed

--- a/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -19,109 +19,18 @@ Resource  ./vicui-common.robot
 Suite Teardown  Close All Connections
 
 *** Keywords ***
-Check If Nimbus VMs Exist
-    # remove testbed-information if it exists
-    ${ti_exists}=  Run Keyword And Return Status  OperatingSystem.Should Exist  testbed-information
-    Run Keyword If  ${ti_exists}  Remove File  testbed-information
-
-    ${nimbus_machines}=  Set Variable  %{NIMBUS_USER}-UITEST-*
-    Log To Console  \nFinding Nimbus machines for UI tests
-    Open SSH Connection  %{NIMBUS_GW}  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-
-    Execute Command  rm -rf public_html/pxe/*
-    ${out}=  Execute Command  nimbus-ctl list | grep -i "${nimbus_machines}"
-    @{out}=  Split To Lines  ${out}
-    ${out_len}=  Get Length  ${out}
-    Close connection
-
-    Run Keyword If  ${out_len} == 0  Setup Testbed  ELSE  Load Testbed  ${out}
-    Create File  testbed-information  TEST_VSPHERE_VER=%{TEST_VSPHERE_VER}\nSELENIUM_SERVER_IP=%{SELENIUM_SERVER_IP}\nTEST_ESX_NAME=%{TEST_ESX_NAME}\nESX_HOST_IP=%{ESX_HOST_IP}\nESX_HOST_PASSWORD=%{ESX_HOST_PASSWORD}\nTEST_VC_NAME=%{TEST_VC_NAME}\nTEST_VC_IP=%{TEST_VC_IP}\nTEST_URL_ARRAY=%{TEST_URL_ARRAY}\nTEST_USERNAME=%{TEST_USERNAME}\nTEST_PASSWORD=%{TEST_PASSWORD}\nTEST_DATASTORE=datastore1\nEXTERNAL_NETWORK=%{EXTERNAL_NETWORK}\nTEST_TIMEOUT=%{TEST_TIMEOUT}\nGOVC_INSECURE=%{GOVC_INSECURE}\nGOVC_USERNAME=%{GOVC_USERNAME}\nGOVC_PASSWORD=%{GOVC_PASSWORD}\nGOVC_URL=%{GOVC_URL}\n
-
 Destroy Testbed
     [Arguments]  ${name}
     Log To Console  Destroying VM(s) ${name}
     Run Keyword And Ignore Error  Kill Nimbus Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  ${name}
 
-Load Testbed
-    [Arguments]  ${list}
-    Log To Console  Retrieving VMs information for UI testing...\n
-    ${len}=  Get Length  ${list}
-    @{browservm-found}=  Create List
-    @{esx-found}=  Create List
-    @{vcsa-found}=  Create List
-    ${browservm-requested}=  Run Keyword If  '%{TEST_OS}' == 'Ubuntu'  Set Variable  BROWSERVM-UBUNTU  ELSE  Set Variable  BROWSERVM-WINDOWS
-    :FOR  ${vm}  IN  @{list}
-    \  @{vm_items}=  Split String  ${vm}  :
-    \  ${is_esx}=  Run Keyword And Return Status  Should Match Regexp  @{vm_items}[1]  (?i)esx%{TEST_VSPHERE_VER}
-    \  ${is_vcsa}=  Run Keyword And Return Status  Should Match Regexp  @{vm_items}[1]  (?i)vc%{TEST_VSPHERE_VER}
-    \  ${is_browservm}=  Run Keyword And Return Status  Should Match Regexp  @{vm_items}[1]  (?i)${browservm-requested}
-    \  Run Keyword If  ${is_browservm}  Set Test Variable  @{browservm-found}  @{vm_items}  ELSE IF  ${is_esx}  Set Test Variable  @{esx-found}  @{vm_items}  ELSE IF  ${is_vcsa}  Set Test Variable  @{vcsa-found}  @{vm_items}
-    ${browservm_len}=  Get Length  ${browservm-found}
-    ${esx_len}=  Get Length  ${esx-found}
-    ${vcsa_len}=  Get Length  ${vcsa-found}
-    Run Keyword If  ${browservm_len} > 0  Extract BrowserVm Info  @{browservm-found}  ELSE  Deploy BrowserVm
-    Run Keyword If  (${esx_len} == 0 and ${vcsa_len} > 0) or (${esx_len} > 0 and ${vcsa_len} == 0)  Run Keywords  Destroy Testbed  %{NIMBUS_USER}-UITEST-VC%{TEST_VSPHERE_VER}*  AND  Destroy Testbed  %{NIMBUS_USER}-UITEST-ESX%{TEST_VSPHERE_VER}*  AND  Deploy Esx  AND  Deploy Vcsa
-    Run Keyword If  ${esx_len} == 0 and ${vcsa_len} == 0  Run Keywords  Deploy Esx  AND  Deploy Vcsa
-    Run Keyword If  ${esx_len} > 0 and ${vcsa_len} > 0  Run Keywords  Extract Esx Info  @{esx-found}  AND  Extract Vcsa Info  @{vcsa-found}
-
-Extract BrowserVm Info
-    [Arguments]  @{vm_fields}
-    Open SSH Connection  %{NIMBUS_GW}  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    ${vm_name}=  Evaluate  '@{vm_fields}[1]'.strip()
-    ${out}=  Execute Command  NIMBUS=@{vm_fields}[0] nimbus-ctl ip ${vm_name} | grep -i ".*: %{NIMBUS_USER}-.*"
-    @{out}=  Split String  ${out}  :
-    ${vm_ip}=  Evaluate  '@{out}[2]'.strip()
-    Run Keyword If  '%{TEST_OS}' == 'Mac'  Set Environment Variable  SELENIUM_SERVER_IP  ${MACOS_HOST_IP}  ELSE IF  '%{TEST_OS}' == 'Ubuntu'  Set Environment Variable  SELENIUM_SERVER_IP  ${UBUNTU_HOST_IP}  ELSE  Set Environment Variable  SELENIUM_SERVER_IP  ${vm_ip}
-    Close Connection
-
-Extract Esx Info
-    [Arguments]  @{vm_fields}
-    Open SSH Connection  %{NIMBUS_GW}  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    ${vm_name}=  Evaluate  '@{vm_fields}[1]'.strip()
-    ${out}=  Execute Command  NIMBUS=@{vm_fields}[0] nimbus-ctl ip ${vm_name} | grep -i ".*: %{NIMBUS_USER}-.*"
-    @{out}=  Split String  ${out}  :
-    ${vm_ip}=  Evaluate  '@{out}[2]'.strip()
-    Set Environment Variable  TEST_ESX_NAME  ${vm_name}
-    Set Environment Variable  ESX_HOST_IP  ${vm_ip}
-    Set Environment Variable  ESX_HOST_PASSWORD  e2eFunctionalTest
-    Close Connection
-
-Extract Vcsa Info
-    [Arguments]  @{vm_fields}
-    Open SSH Connection  %{NIMBUS_GW}  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    ${vm_name}=  Evaluate  '@{vm_fields}[1]'.strip()
-    ${out}=  Execute Command  NIMBUS=@{vm_fields}[0] nimbus-ctl ip ${vm_name} | grep -i ".*: %{NIMBUS_USER}-.*"
-    @{out}=  Split String  ${out}  :
-    ${vm_ip}=  Evaluate  '@{out}[2]'.strip()
-    Set Environment Variable  TEST_VC_NAME  ${vm_name}
-    Set Environment Variable  TEST_VC_IP  ${vm_ip}
-    Set Environment Variable  TEST_URL_ARRAY  ${vm_ip}
-    Set Environment Variable  TEST_USERNAME  Administrator@vsphere.local
-    Set Environment Variable  TEST_PASSWORD  Admin\!23
-    Set Environment Variable  EXTERNAL_NETWORK  vm-network
-    Set Environment Variable  TEST_TIMEOUT  30m
-    Set Environment Variable  GOVC_INSECURE  1
-    Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local
-    Set Environment Variable  GOVC_PASSWORD  Admin\!23
-    Set Environment Variable  GOVC_URL  ${vm_ip}
-    Close Connection
-
-Deploy BrowserVm
-    # deploy a browser vm
-    ${browservm}  ${browservm-ip}=  Run Keyword If  '%{TEST_OS}' == 'Mac'  No Operation  ELSE IF  '%{TEST_OS}' == 'Ubuntu'  No Operation  ELSE  Deploy Windows BrowserVm  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    Run Keyword If  '%{TEST_OS}' == 'Mac'  Set Environment Variable  SELENIUM_SERVER_IP  ${MACOS_HOST_IP}  ELSE IF  '%{TEST_OS}' == 'Ubuntu'  Set Environment Variable  SELENIUM_SERVER_IP  ${UBUNTU_HOST_IP}  ELSE  Set Environment Variable  SELENIUM_SERVER_IP  ${browservm-ip}
-
 Deploy Esx
-    [Arguments]  ${build}=None  ${logfile}=None
-    # deploy an esxi server
-    ${name}=  Evaluate  'UITEST-ESX%{TEST_VSPHERE_VER}-' + str(random.randint(1000,9999))  modules=random
-    ${buildnum}=  Run Keyword If  ${build} is not None  Set Variable  ${build}  ELSE  Run Keyword If  %{TEST_VSPHERE_VER} == 60  Set Variable  3620759  ELSE  Set Variable  5310538
-
-    Log To Console  \nDeploying Nimbus ESXi server: ${name}
-
+    [Arguments]  ${name}  ${build}=None  ${logfile}=None
     Open SSH Connection  %{NIMBUS_GW}  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  retry_interval=30 sec
-    # run nimbus command and make sure deployment was successful
-    ${output}=  Execute Command  nimbus-esxdeploy ${name} --disk\=50000000 --memory\=8192 --lease=1 --nics 2 ${buildnum}
+    Execute Command  rm -rf public_html/pxe/*
+
+    ${output}=  Execute Command  nimbus-esxdeploy ${name} --disk\=50000000 --memory\=8192 --lease=1 --nics 2 ${build}
+    Log  ${output}
     Run Keyword If  ${logfile} is not None  Create File  ${logfile}  ${output}
     Should Contain  ${output}  To manage this VM use
 
@@ -135,21 +44,15 @@ Deploy Esx
     Log To Console  Successfully deployed %{NIMBUS_USER}-${name}. IP: ${esx1-ip}
     Close Connection
 
-    Set Environment Variable  TEST_ESX_NAME  %{NIMBUS_USER}-${name}
-    Set Environment Variable  ESX_HOST_IP  ${esx1-ip}
-    Set Environment Variable  ESX_HOST_PASSWORD  e2eFunctionalTest
+    [Return]  %{NIMBUS_USER}-${name}  ${esx1-ip}
 
 Deploy Vcsa
-    [Arguments]  ${build}=None  ${logfile}=None
-    # deploy a vcsa
-    ${name}=  Evaluate  'UITEST-VC%{TEST_VSPHERE_VER}-' + str(random.randint(1000,9999))  modules=random
-    ${buildnum}=  Run Keyword If  ${build} is not None  Set Variable  ${build}  ELSE  Run Keyword If  %{TEST_VSPHERE_VER} == 60  Set Variable  3634791  ELSE  Set Variable  7312210
-
-    Log To Console  \nDeploying Nimbus VC server: ${name}
-
+    [Arguments]  ${name}  ${build}  ${esxi_list}  ${logfile}=None
     Open SSH Connection  %{NIMBUS_GW}  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  retry_interval=30 sec
+
     # run nimbus command and make sure deployment was successful
-    ${output}=  Execute Command  nimbus-vcvadeploy --lease\=1 --useQaNgc --vcvaBuild ${buildnum} ${name}
+    ${output}=  Execute Command  nimbus-vcvadeploy --lease\=1 --useQaNgc --vcvaBuild ${build} ${name}
+    Log  ${output}
     Run Keyword If  ${logfile} is not None  Create File  ${logfile}  ${output}
     Should Contain  ${output}  To manage this VM use
     
@@ -174,9 +77,18 @@ Deploy Vcsa
     Should Be Empty  ${out}
 
     # add the esx host to the cluster
-    Log To Console  Add ESX host to Cluster
-    ${out}=  Run  govc cluster.add -dc=Datacenter -cluster=/Datacenter/host/Cluster -username=root -password=e2eFunctionalTest -noverify=true -hostname=%{ESX_HOST_IP}
-    Should Contain  ${out}  OK
+    :FOR  ${esxi}  IN  @{esxi_list}
+    \  ${esxi_name}=  Get From Dictionary  ${esxi}  name
+    \  ${esxi_ip}=  Get From Dictionary  ${esxi}  ip
+    \  ${is_standalone}=  Run Keyword And Return Status  Dictionary Should Contain Key  ${esxi}  standalone
+    \  Run Keyword Unless  ${is_standalone}  Log To Console  Add ESX host ${esxi_name} to Cluster
+    \  Run Keyword If  ${is_standalone}  Log To Console  Add standalone ESX host ${esxi_name}
+    \  ${out_cluster}=  Run Keyword Unless  ${is_standalone}  Run  govc cluster.add -dc=Datacenter -cluster=/Datacenter/host/Cluster -username=root -password=e2eFunctionalTest -noverify=true -hostname=${esxi_ip}
+    \  ${out_standalone}=  Run Keyword If  ${is_standalone}  Run  govc host.add -dc=Datacenter -username=root -password=e2eFunctionalTest -noverify=true -hostname=${esxi_ip}
+    \  Run Keyword Unless  ${is_standalone}  Log  ${out_cluster}
+    \  Run Keyword Unless  ${is_standalone}  Should Contain  ${out_cluster}  OK
+    \  Run Keyword If  ${is_standalone}  Log  ${out_standalone}
+    \  Run Keyword If  ${is_standalone}  Should Contain  ${out_standalone}  OK
 
     # create a distributed switch
     Log To Console  Create a distributed switch
@@ -192,123 +104,85 @@ Deploy Vcsa
     ${out}=  Run  govc dvs.portgroup.add -nports 12 -dc=Datacenter -dvs=test-ds network
     Should Contain  ${out}  OK
 
-    Log To Console  Add the ESXi hosts to the portgroups
-    ${out}=  Run  govc dvs.add -dvs=test-ds -pnic=vmnic1 -host.ip=%{ESX_HOST_IP} %{ESX_HOST_IP}
-    Should Contain  ${out}  OK
+    :FOR  ${esxi}  IN  @{esxi_list}
+    \  ${esxi_name}=  Get From Dictionary  ${esxi}  name
+    \  ${esxi_ip}=  Get From Dictionary  ${esxi}  ip
+    \  Log To Console  Add the ESXi host ${esxi_name} to the portgroups
+    \  ${out}=  Run  govc dvs.add -dvs=test-ds -pnic=vmnic1 -host.ip=${esxi_ip} ${esxi_ip}
+    \  Log  ${out}
+    \  Should Contain  ${out}  OK
 
-    Set Environment Variable  TEST_VC_NAME  %{NIMBUS_USER}-${name}
-    Set Environment Variable  TEST_VC_IP  ${vc-ip}
-    Set Environment Variable  TEST_URL_ARRAY  ${vc-ip}
-    Set Environment Variable  TEST_USERNAME  Administrator@vsphere.local
-    Set Environment Variable  TEST_PASSWORD  Admin\!23
-    Set Environment Variable  EXTERNAL_NETWORK  vm-network
-    Set Environment Variable  TEST_TIMEOUT  30m
-    Set Environment Variable  GOVC_INSECURE  1
-    Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local
-    Set Environment Variable  GOVC_PASSWORD  Admin\!23
-    Set Environment Variable  GOVC_URL  ${vc-ip}
+    [Return]  %{NIMBUS_USER}-${name}  ${vc-ip}
 
-Setup Testbed
-    Deploy BrowserVm
-    Deploy Esx
-    Deploy Vcsa
+Prepare VIC UI Testbed
+    [Arguments]  ${testbed_config}
+    ${randname_snippet}=  Evaluate  'E2E-' + str(random.randint(1000,9999))  modules=random
+    Set Environment Variable  E2E_RUN_NUMBER  ${randname_snippet}
 
-Deploy Windows BrowserVm
-    [Arguments]  ${user}  ${password}  ${vm-template}=hsuia-seleniumNode-w7x64
-    ${os}=  Set Variable  WINDOWS
-    ${name}=  Evaluate  'UITEST-BROWSERVM-${os}-' + str(random.randint(1000,9999))  modules=random
-    Log To Console  \nDeploying Browser VM: ${name}
-    Open SSH Connection  %{NIMBUS_GW}  ${user}  ${password}
+    # Deploy the given number of ESXis    
+    ${esxbuild}=  Get From Dictionary  ${testbed_config}  esx_build
+    ${esxnum}=  Get From Dictionary  ${testbed_config}  esx_num
+    ${esxnum}=  Evaluate  ${esxnum} + 1
 
-    ${out}=  Execute Command  nimbus-genericdeploy --type ${vm-template} ${name} --lease 1
-    # Make sure the deploy actually worked
-    Should Contain  ${out}  To manage this VM use
-    # Now grab the IP address and return the name and ip for later use
-    @{out}=  Split To Lines  ${out}
-    :FOR  ${item}  IN  @{out}
-    \   ${status}  ${message}=  Run Keyword And Ignore Error  Should Contain  ${item}  IP is
-    \   Run Keyword If  '${status}' == 'PASS'  Set Suite Variable  ${line}  ${item}
-    @{gotIP}=  Split String  ${line}  ${SPACE}
-    ${ip}=  Remove String  @{gotIP}[5]  ,
+    @{pids}=  Create List
+    @{esxi_names}=  Create List
+    @{esxi_deploy_results}=  Create List
 
-    Log To Console  Successfully deployed new Browser VM - ${user}-${name}
-    Close connection
-    [Return]  ${user}-${name}  ${ip}
+    # asynchronously deploy ESXi and VC VMs
+    :FOR  ${idx}  IN RANGE  1  ${esxnum}
+    \  ${name}=  Evaluate  '${randname_snippet}-ESX-${esxbuild}-${idx}'
+    \  Append To List  ${esxi_names}  ${name}
+    \  Log To Console  \nDeploying Nimbus ESXi server: ${name}
+    \  ${vm_name}  ${vm_ip}=  Deploy Esx  ${name}  ${esxbuild}
+    \  &{vm}=  Create Dictionary
+    \  Set To Dictionary  ${vm}  name  ${vm_name}
+    \  Set To Dictionary  ${vm}  ip  ${vm_ip}
+    \  Set To Dictionary  ${vm}  build  ${esxbuild}
+    \  ${idx}=  Get Index from List  ${esxi_names}  ${name}
+    \  ${standalone_host_idx}=  Evaluate  ${esxnum} - 2
+    \  Run Keyword If  ${idx} == ${standalone_host_idx}  Set To Dictionary  ${vm}  standalone  ${TRUE}
+    \  Append To List  ${esxi_deploy_results}  ${vm}
+
+    Log To Console  \nESXi deployment completed
+
+    ${vcbuild}=  Get From Dictionary  ${testbed_config}  vc_build
+    ${vc_name}=  Evaluate  '${randname_snippet}-VC-${vcbuild}'
+    Log To Console  \nDeploying Nimbus vCenter server: ${vc_name}
+    ${vm_name}  ${vm_ip}=  Deploy Vcsa  ${vc_name}  ${vcbuild}  ${esxi_deploy_results}
+    &{vc_deploy_results}=  Create Dictionary
+    Set To Dictionary  ${vc_deploy_results}  name  ${vm_name}
+    Set To Dictionary  ${vc_deploy_results}  ip  ${vm_ip}
+    Set To Dictionary  ${vc_deploy_results}  build  ${vcbuild}
+
+    [Return]  ${esxi_deploy_results}  ${vc_deploy_results}
 
 *** Test Cases ***
-Predeploy Vc And Esx
-    [Tags]  presetup
-    Load Secrets  ../../../ui/vic-uia/test.secrets
-    Environment Variable Should Be Set  NIMBUS_USER
-    Environment Variable Should Be Set  NIMBUS_GW
-    Environment Variable Should Be Set  NIMBUS_PASSWORD
-    Environment Variable Should Be Set  TEST_DATASTORE
-    Environment Variable Should Be Set  TEST_RESOURCE
-    Set Environment Variable  GOVC_INSECURE  1
-    @{VSPHERE_BUILDS_LIST}=  Create List
-    Append To List  ${VSPHERE_BUILDS_LIST}  65-5310538-7312210
-
-    Log To Console  \n==============================================================================
-    Log To Console  This script will destroy all vSphere 6.0 and 6.5 instances plus Windows Browser VM
-    Log To Console  on Nimbus and redeploy them. If you wish to cancel, press ctrl + c within 10 seconds.
-    Log To Console  ==============================================================================
-    Sleep  10s
-
-    :FOR  ${item}  IN  @{VSPHERE_BUILDS_LIST}
-    \  @{split}=  Split String  ${item}  -
-    \  Set Environment Variable  TEST_VSPHERE_VER  @{split}[0]
-    \  Log To Console  \nDestroying any existing ESX instance: %{NIMBUS_USER}-UITEST-ESX@{split}[0]*...
-    \  Destroy Testbed  %{NIMBUS_USER}-UITEST-ESX@{split}[0]*
-    \  Log To Console  Deploying an ESXi instance with build ob-@{split}[1]...
-    \  Deploy Esx  @{split}[1]
-    \  Log To Console  \nDestroying any existing VC instance: %{NIMBUS_USER}-UITEST-VC@{split}[0]*...
-    \  Destroy Testbed  %{NIMBUS_USER}-UITEST-VC@{split}[0]*
-    \  Log To Console  \nDeploying a VC instance with build ob-@{split}[2]...
-    \  Deploy Vcsa  @{split}[2]
-
-    Log To Console  \nDestroying Windows VM instance: %{NIMBUS_USER}-UITEST-BROWSERVM-WINDOWS*...
-    Destroy Testbed  %{NIMBUS_USER}-UITEST-BROWSERVM-WINDOWS*
-    Log To Console  \nDeploying a Windows Browser wVM instance using template hsuia-seleniumNode-w7x64...
-    Deploy Windows BrowserVm  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  hsuia-seleniumNode-w7x64
-
-Check Variables
-    ${isset_SHELL}=  Run Keyword And Return Status  Environment Variable Should Be Set  SHELL
-    ${isset_GOVC_INSECURE}=  Run Keyword And Return Status  Environment Variable Should Be Set  GOVC_INSECURE
-    Log To Console  \nChecking environment variables
-    Log To Console  SHELL ${isset_SHELL}
-    Log To Console  GOVC_INSECURE ${isset_GOVC_INSECURE}
-    Log To Console  TEST_VSPHERE_VER %{TEST_VSPHERE_VER}
-    Should Be True  ${isset_SHELL} and ${isset_GOVC_INSECURE} and %{TEST_VSPHERE_VER}
-
-Get VMs Information
+Deploy VICUI Testbed
     # remove testbed-information if it exists
     ${ti_exists}=  Run Keyword And Return Status  OperatingSystem.Should Exist  testbed-information
     Run Keyword If  ${ti_exists}  Remove File  testbed-information
 
-    # choose which selenium grid to use
-    Run Keyword If  '%{TEST_OS}' == 'Mac'  Set Environment Variable  SELENIUM_SERVER_IP  ${MACOS_HOST_IP}  ELSE  Set Environment Variable  SELENIUM_SERVER_IP  ${WINDOWS_HOST_IP}
+    &{testbed_config}=  Create Dictionary
 
-    ${esx_ip}=  Set Variable  ${BUILD_%{TEST_ESX_BUILD}_IP}
-    ${vcsa_ip}=  Set Variable  ${BUILD_%{TEST_VCSA_BUILD}_IP}
+    Set To Dictionary  ${testbed_config}  esx_num  3
+    Set To Dictionary  ${testbed_config}  esx_build  5969303
+    Set To Dictionary  ${testbed_config}  vc_build  7515524
+
+    ${esxis}  ${vc}=  Prepare VIC UI Testbed  ${testbed_config}
+    ${vc_ip}=  Get From Dictionary  ${vc}  ip
 
     ${testbed-information-content}=  Catenate  SEPARATOR=\n
-    ...  TEST_VSPHERE_VER=%{TEST_VSPHERE_VER}
-    ...  SELENIUM_SERVER_IP=%{SELENIUM_SERVER_IP}
-    ...  TEST_ESX_NAME=esx-%{TEST_ESX_BUILD}
-    ...  ESX_HOST_IP=${esx_ip}
-    ...  ESX_HOST_PASSWORD=ca*hc0w
-    ...  TEST_VC_NAME=vc-%{TEST_VCSA_BUILD}
-    ...  TEST_VC_IP=${vcsa_ip}
-    ...  TEST_URL_ARRAY=${vcsa_ip}
+    ...  TEST_VSPHERE_VER=65
+    ...  TEST_VC_IP=${vc_ip}
+    ...  TEST_URL_ARRAY=${vc_ip}
     ...  TEST_USERNAME=Administrator@vsphere.local
     ...  TEST_PASSWORD=Admin\!23
-    ...  TEST_DATASTORE=${TEST_DATASTORE}
     ...  EXTERNAL_NETWORK=vm-network
     ...  TEST_TIMEOUT=30m
     ...  GOVC_INSECURE=1
     ...  GOVC_USERNAME=Administrator@vsphere.local
     ...  GOVC_PASSWORD=Admin\!23
-    ...  GOVC_URL=${vcsa_ip}\n
+    ...  GOVC_URL=${vc_ip}\n
 
     Create File  testbed-information  ${testbed-information-content}
 
@@ -325,7 +199,6 @@ Deploy VCH
     Append To File  testbed-information  TEST_OS=%{TEST_OS}\n
     Append To File  testbed-information  DRONE_BUILD_NUMBER=%{DRONE_BUILD_NUMBER}\n
     Append To File  testbed-information  BRIDGE_NETWORK=%{BRIDGE_NETWORK}\n
-    Append To File  testbed-information  TEST_DATACENTER=${TEST_DATACENTER}\n
     Append To File  testbed-information  TEST_URL=%{TEST_URL}\n
     Append To File  testbed-information  VCH_VM_NAME=%{VCH-NAME}\n
     Append To File  testbed-information  VCH-IP=%{VCH-IP}\n

--- a/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -18,6 +18,9 @@ Resource  ../../resources/Util.robot
 Resource  ./vicui-common.robot
 Suite Teardown  Close All Connections
 
+*** Variables ***
+${ESXIS_NUM}  3
+
 *** Keywords ***
 Destroy Testbed
     [Arguments]  ${name}
@@ -177,7 +180,7 @@ Deploy VICUI Testbed
 
     &{testbed_config}=  Create Dictionary
 
-    Set To Dictionary  ${testbed_config}  esx_num  3
+    Set To Dictionary  ${testbed_config}  esx_num  ${ESXIS_NUM}
     Set To Dictionary  ${testbed_config}  esx_build  5969303
     Set To Dictionary  ${testbed_config}  vc_build  7515524
 
@@ -192,6 +195,10 @@ Deploy VICUI Testbed
     Set Global Variable  ${ESXIs}  ${esxis}
     Set Global Variable  ${VCIP}  ${vc_fqdn}
 
+    ${last_esxi_index}=  Evaluate  ${ESXIS_NUM} - 1
+    ${standalone_esxi}=  Get From List  ${esxis}  ${last_esxi_index}
+    ${standalone_esxi_ip}=  Get From Dictionary  ${standalone_esxi}  ip
+
     ${testbed-information-content}=  Catenate  SEPARATOR=\n
     ...  TEST_VSPHERE_VER=65
     ...  TEST_VC_IP=${vc_fqdn}
@@ -204,7 +211,8 @@ Deploy VICUI Testbed
     ...  GOVC_INSECURE=1
     ...  GOVC_USERNAME=Administrator@vsphere.local
     ...  GOVC_PASSWORD=Admin\!23
-    ...  GOVC_URL=${vc_fqdn}\n
+    ...  GOVC_URL=${vc_fqdn}
+    ...  STANDALONE_ESX1_IP=${standalone_esxi_ip}\n
 
     Create File  testbed-information-%{BUILD_NUMBER}  ${testbed-information-content}
 

--- a/tests/test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/test-cases/Group18-VIC-UI/vicui-common.robot
@@ -21,7 +21,7 @@ Library  XML
 *** Variables ***
 ${MACOS_HOST_IP}                      10.25.201.232
 ${UBUNTU_HOST_IP}                     10.20.121.145
-${WINDOWS_HOST_IP}                    10.25.200.225
+${WINDOWS_HOST_IP}                    10.25.200.93
 ${BUILD_5310538_IP}                   10.25.200.231
 ${BUILD_7312210_IP}                   10.25.201.234
 ${VC_FINGERPRINT_7312210}             FE:31:A9:D1:48:D7:0E:1D:44:75:F8:D9:64:50:8B:B9:30:93:EF:63
@@ -30,7 +30,7 @@ ${TEST_DATACENTER}                    /Datacenter
 ${TEST_RESOURCE}                      /Datacenter/host/Cluster/Resources
 ${MACOS_HOST_USER}                    browseruser
 ${MACOS_HOST_PASSWORD}                ca*hc0w
-${WINDOWS_HOST_USER}                  IEUser
+${WINDOWS_HOST_USER}                  Administrator
 ${WINDOWS_HOST_PASSWORD}              Passw0rd!
 ${vic_macmini_fileserver_url}         https://${MACOS_HOST_IP}:3443/vsphere-plugins/
 ${vic_macmini_fileserver_thumbprint}  BE:64:39:8B:BD:98:47:4D:E8:3B:2F:20:A5:21:8B:86:5F:AD:79:CE

--- a/tests/test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/test-cases/Group18-VIC-UI/vicui-common.robot
@@ -468,7 +468,7 @@ Configure Vcsa
     \  Log  ${out}
     \  Should Contain  ${out}  OK
 
-    [Return]  %{NIMBUS_USER}-${name}
+    [Return]  svc.vic-ui-${name}
 
 Deploy ESXi On Nimbus And Get Info
     [Arguments]  ${name}  ${build}
@@ -489,8 +489,8 @@ Deploy ESXi On Nimbus And Get Info
     Set Environment Variable  GOVC_URL  root:@${esxi_ip}
     ${out}=  Run  govc host.account.update -id root -password e2eFunctionalTest
     Should Be Empty  ${out}
-    Log To Console  Successfully deployed %{NIMBUS_USER}-${name}. IP: ${esxi_ip}
-    [Return]  %{NIMBUS_USER}-${name}  ${esxi_ip}
+    Log To Console  Successfully deployed svc.vic-ui-${name}. IP: ${esxi_ip}
+    [Return]  svc.vic-ui-${name}  ${esxi_ip}
 
 Destroy Testbed
     [Arguments]  ${name}

--- a/tests/test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/test-cases/Group18-VIC-UI/vicui-common.robot
@@ -53,8 +53,9 @@ Set Fileserver And Thumbprint In Configs
     Create File  ${UI_INSTALLER_PATH}/configs  ${results}
 
 Load Nimbus Testbed Env
-    Should Exist  testbed-information
-    ${envs}=  OperatingSystem.Get File  testbed-information
+    [Arguments]  ${file}=testbed-information
+    Should Exist  ${file}
+    ${envs}=  OperatingSystem.Get File  ${file}
     @{envs}=  Split To Lines  ${envs}
     :FOR  ${item}  IN  @{envs}
     \  @{kv}=  Split String  ${item}  =

--- a/tests/test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/test-cases/Group18-VIC-UI/vicui-common.robot
@@ -476,23 +476,18 @@ Deploy ESXi On Nimbus And Get Info
     ${results}=  Wait For Process  ${pid}
     Should Contain  ${results.stdout}  To manage this VM use
 
-    # remember previous govc env vars
-    ${govc_url}=  Set Variable  %{GOVC_URL}
-    ${govc_username}=  Set Variable  %{GOVC_USERNAME}
-    ${govc_password}=  Set Variable  %{GOVC_PASSWORD}
-
     Open SSH Connection  %{NIMBUS_GW}  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  retry_interval=30 sec
-    Remove Environment Variable  GOVC_PASSWORD
-    Remove Environment Variable  GOVC_USERNAME
+    ${govc_username_set}=  Run Keyword And Return Status  Environment Variable Should Be Set  GOVC_USERNAME
+    ${govc_password_set}=  Run Keyword And Return Status  Environment Variable Should Be Set  GOVC_PASSWORD
+    Run Keyword If  ${govc_username_set}  Remove Environment Variable  GOVC_USERNAME
+    Run Keyword If  ${govc_password_set}  Remove Environment Variable  GOVC_PASSWORD
+
     Set Environment Variable  GOVC_INSECURE  1
     
     ${esxi_ip}=  Get IP  ${name}
     Close Connection
     Set Environment Variable  GOVC_URL  root:@${esxi_ip}
     ${out}=  Run  govc host.account.update -id root -password e2eFunctionalTest
-    Set Environment Variable  GOVC_URL  ${govc_url}
-    Set Environment Variable  GOVC_USERNAME  ${govc_username}
-    Set Environment Variable  GOVC_PASSWORD  ${govc_password}
     Should Be Empty  ${out}
     Log To Console  Successfully deployed %{NIMBUS_USER}-${name}. IP: ${esxi_ip}
     [Return]  %{NIMBUS_USER}-${name}  ${esxi_ip}

--- a/tests/test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/test-cases/Group18-VIC-UI/vicui-common.robot
@@ -169,8 +169,6 @@ Delete VIC Machine
 
 Uninstall VCH
     [Arguments]  ${remove_plugin}=${FALSE}
-    Log To Console  Gathering logs from the test server...
-    Gather Logs From Test Server
     Log To Console  Deleting the VCH appliance...
     ${uname_v}=  Run  uname -v
     ${is_macos}=  Run Keyword And Return Status  Should Contain  ${uname_v}  Darwin

--- a/tests/test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/test-cases/Group18-VIC-UI/vicui-common.robot
@@ -42,9 +42,9 @@ ${ENV_HTML_SDK_HOME}                  /tmp/sdk/html-client-sdk
 
 *** Keywords ***
 Set Fileserver And Thumbprint In Configs
-    [Arguments]  ${fake}=${FALSE}
-    Run Keyword If  ${fake} == ${FALSE}  Copy File  ../../../ui-nightly-run-bin/ui/VCSA/configs  ../../../scripts/VCSA/
-    Run Keyword If  ${fake} == ${FALSE}  Copy File  ../../../ui-nightly-run-bin/ui/vCenterForWindows/configs  ../../../scripts/vCenterForWindows/
+    [Arguments]  ${fake}=${FALSE}  ${root}=../../..
+    Run Keyword If  ${fake} == ${FALSE}  Copy File  ${root}/ui-nightly-run-bin/ui/VCSA/configs  ${root}/scripts/VCSA/
+    Run Keyword If  ${fake} == ${FALSE}  Copy File  ${root}/ui-nightly-run-bin/ui/vCenterForWindows/configs  ${root}/scripts/vCenterForWindows/
     Return From Keyword If  ${fake} == ${FALSE}
 
     ${fileserver_url}=  Set Variable  https://256.256.256.256/
@@ -129,10 +129,11 @@ Reset Configs
     Should Exist  ${UI_INSTALLER_PATH}/configs
 
 Force Install Vicui Plugin
+    [Arguments]  ${root}=../../..
     ${rc}  ${ver}=  Run And Return Rc And Output  ver
     ${is_windows}=  Run Keyword And Return Status  Should Contain  ${ver}  Windows
     ${vic-ui-binary}=  Run Keyword If  ${is_windows}  Set Variable  ..\\..\\..\\vic-ui-windows  ELSE  Set Variable  ../../../vic-ui-linux
-    Set Fileserver And Thumbprint In Configs
+    Set Fileserver And Thumbprint In Configs  ${FALSE}  ${root}
     Run Keyword Unless  ${is_windows}  Append To File  ${UI_INSTALLER_PATH}/configs  BYPASS_PLUGIN_VERIFICATION=1\n
     Run Keyword If  ${is_windows}  Interact With Script  install  -f -i ${TEST_VC_IP} -u ${TEST_VC_USERNAME} -p ${TEST_VC_PASSWORD}  ${EMPTY}  True  ELSE  Install Plugin Successfully  ${TEST_VC_IP}  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}  ${TRUE}  None  ${TRUE}
     Run Keyword Unless  ${is_windows}  Reset Configs
@@ -245,7 +246,7 @@ Install VIC Product OVA
     Set Environment Variable  GOVC_INSECURE  1
     Set Environment Variable  GOVC_USERNAME  administrator@vsphere.local
     Set Environment Variable  GOVC_PASSWORD  Admin!23
-    ${rc}  ${ova_ip}=  Run And Return Rc And Output  govc vm.ip ${ova-name}
+    ${rc}  ${ova_ip}=  Run And Return Rc And Output  govc vm.ip -dc=Datacenter ${ova-name}
     ${ova_found}=  Run Keyword And Return Status  Should Be True  ${rc} == 0
 
     # if ova is already found in the target VC, get IP and break out of the keyword

--- a/tests/test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/test-cases/Group18-VIC-UI/vicui-common.robot
@@ -400,20 +400,20 @@ Run SSHPASS And Log To File
 Deploy ESXi Server On Nimbus Async
     [Arguments]  ${name}  ${build}=None
     Log To Console  \nDeploying Nimbus ESXi server: ${name}
-    ${cmd}=  Evaluate  'USER=svc.vic-ui nimbus-esxdeploy ${name} --disk\=50000000 --memory\=8192 --lease=1 --nics 2 ${build}'
+    ${cmd}=  Evaluate  'nimbus-esxdeploy ${name} --disk\=50000000 --memory\=8192 --lease=1 --nics 2 ${build}'
     ${out}=  Run SSHPASS And Log To File  %{NIMBUS_GW}  %{NIMBUS_USER}  '%{NIMBUS_PASSWORD}'  ${cmd}  sshpass-stdout-${name}.log
     [Return]  ${out}
 
 Deploy VC On Nimbus Async
     [Arguments]  ${name}  ${build}=None
     Log To Console  \nDeploying Nimbus VC server: ${name}
-    ${cmd}=  Evaluate  'USER=svc.vic-ui nimbus-vcvadeploy --lease\=1 --useQaNgc --vcvaBuild ${build} ${name}'
+    ${cmd}=  Evaluate  'nimbus-vcvadeploy --lease\=1 --useQaNgc --vcvaBuild ${build} ${name}'
     ${out}=  Run SSHPASS And Log To File  %{NIMBUS_GW}  %{NIMBUS_USER}  '%{NIMBUS_PASSWORD}'  ${cmd}  sshpass-stdout-${name}.log
     [Return]  ${out}
 
 Configure Vcsa
     [Arguments]  ${name}  ${vc_fqdn}  ${esxi_list}
-    Open SSH Connection  ${vc_fqdn}  root  Admin\!23  retry_interval=30 sec
+    Open SSH Connection  ${vc_fqdn}  root  vmware  retry_interval=30 sec
     ${stdout}  ${rc}=  Execute Command  /usr/lib/vmware-vmafd/bin/dir-cli password change --account administrator@vsphere.local --current 'Admin!23' --new 'Bl*ckwalnut0' 2>&1  return_rc=True
     Should Be Equal As Integers  ${rc}  0
     Log To Console  ${stdout}
@@ -474,7 +474,7 @@ Configure Vcsa
     \  Log  ${out}
     \  Should Contain  ${out}  OK
 
-    [Return]  svc.vic-ui-${name}
+    [Return]  %{NIMBUS_USER}-${name}
 
 Deploy ESXi On Nimbus And Get Info
     [Arguments]  ${name}  ${build}
@@ -495,8 +495,8 @@ Deploy ESXi On Nimbus And Get Info
     Set Environment Variable  GOVC_URL  root:@${esxi_ip}
     ${out}=  Run  govc host.account.update -id root -password e2eFunctionalTest
     Should Be Empty  ${out}
-    Log To Console  Successfully deployed svc.vic-ui-${name}. IP: ${esxi_ip}
-    [Return]  svc.vic-ui-${name}  ${esxi_ip}
+    Log To Console  Successfully deployed %{NIMBUS_USER}-${name}. IP: ${esxi_ip}
+    [Return]  %{NIMBUS_USER}-${name}  ${esxi_ip}
 
 Destroy Testbed
     [Arguments]  ${name}

--- a/tests/test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/test-cases/Group18-VIC-UI/vicui-common.robot
@@ -106,7 +106,7 @@ Set Absolute Script Paths
     ${is_windows}=  Run Keyword And Return Status  Should Contain  ${out}  Windows
     Run Keyword If  ${is_windows}  Set Suite Variable  ${UI_INSTALLER_PATH}  ${UI_INSTALLERS_ROOT}/vCenterForWindows  ELSE  Set Suite Variable  ${UI_INSTALLER_PATH}  ${UI_INSTALLERS_ROOT}/VCSA
     Should Exist  ${UI_INSTALLER_PATH}
-    ${configs_content}=  OperatingSystem.GetFile  ${UI_INSTALLER_PATH}/configs-%{TEST_VCSA_BUILD}
+    ${configs_content}=  OperatingSystem.GetFile  ${UI_INSTALLER_PATH}/configs
     Set Suite Variable  ${configs}  ${configs_content}
     Run Keyword If  %{TEST_VSPHERE_VER} == 65  Set Suite Variable  ${plugin_folder}  plugin-packages  ELSE  Set Suite Variable  ${plugin_folder}  vsphere-client-serenity
 
@@ -327,8 +327,6 @@ Prepare VIC Engine Binaries
     Run  cp -rf ui-nightly-run-bin/vic-ui-* ./
     Run  cp -rf ui-nightly-run-bin/ui/* scripts/
     Run  cp -rf scripts/ui/vCenterForWindows/utils* 2>/dev/null
-    Run  cp scripts/VCSA/configs scripts/VCSA/configs-${vc-build}
-    Run  cp scripts/vCenterForWindows/configs scripts/vCenterForWindows/configs-${vc-build}
 
 Open SSH Connection
   [Arguments]  ${host}  ${user}  ${pass}  ${port}=22  ${retry}=2 minutes  ${retry_interval}=5 seconds

--- a/tests/test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/test-cases/Group18-VIC-UI/vicui-common.robot
@@ -400,14 +400,14 @@ Run SSHPASS And Log To File
 Deploy ESXi Server On Nimbus Async
     [Arguments]  ${name}  ${build}=None
     Log To Console  \nDeploying Nimbus ESXi server: ${name}
-    ${cmd}=  Evaluate  'nimbus-esxdeploy ${name} --disk\=50000000 --memory\=8192 --lease=1 --nics 2 ${build}'
+    ${cmd}=  Evaluate  'USER=svc.vic-ui nimbus-esxdeploy ${name} --disk\=50000000 --memory\=8192 --lease=1 --nics 2 ${build}'
     ${out}=  Run SSHPASS And Log To File  %{NIMBUS_GW}  %{NIMBUS_USER}  '%{NIMBUS_PASSWORD}'  ${cmd}  sshpass-stdout-${name}.log
     [Return]  ${out}
 
 Deploy VC On Nimbus Async
     [Arguments]  ${name}  ${build}=None
     Log To Console  \nDeploying Nimbus VC server: ${name}
-    ${cmd}=  Evaluate  'nimbus-vcvadeploy --lease\=1 --useQaNgc --vcvaBuild ${build} ${name}'
+    ${cmd}=  Evaluate  'USER=svc.vic-ui nimbus-vcvadeploy --lease\=1 --useQaNgc --vcvaBuild ${build} ${name}'
     ${out}=  Run SSHPASS And Log To File  %{NIMBUS_GW}  %{NIMBUS_USER}  '%{NIMBUS_PASSWORD}'  ${cmd}  sshpass-stdout-${name}.log
     [Return]  ${out}
 

--- a/tests/test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/test-cases/Group18-VIC-UI/vicui-common.robot
@@ -245,7 +245,7 @@ Install VIC Product OVA
     Set Environment Variable  GOVC_URL  ${target-vc-ip}
     Set Environment Variable  GOVC_INSECURE  1
     Set Environment Variable  GOVC_USERNAME  administrator@vsphere.local
-    Set Environment Variable  GOVC_PASSWORD  Admin!23
+    Set Environment Variable  GOVC_PASSWORD  Bl*ckwalnut0
     ${rc}  ${ova_ip}=  Run And Return Rc And Output  govc vm.ip -dc=Datacenter ${ova-name}
     ${ova_found}=  Run Keyword And Return Status  Should Be True  ${rc} == 0
 
@@ -259,8 +259,8 @@ Install VIC Product OVA
     Run Keyword Unless  ${ova_exists}  Download VIC OVA  ${ova_url}  ${ova_local_path}
 
     Log To Console  \nInstalling VIC appliance...
-    Log To Console  \novftool --datastore='${ova-esx-datastore}' --noSSLVerify --acceptAllEulas --name=${ova-name} --diskMode=thin --powerOn --X:waitForIp --X:injectOvfEnv --X:enableHiddenProperties --prop:appliance.root_pwd='Admin!23' --prop:appliance.permit_root_login=True --net:"Network"="VM Network" ${ova_local_path} 'vi://administrator@vsphere.local:Admin!23@${target-vc-ip}${TEST_DATACENTER}/host/${ova-esx-host-ip}'\n
-    ${output}=  Run  ovftool --datastore='${ova-esx-datastore}' --noSSLVerify --acceptAllEulas --name=${ova-name} --diskMode=thin --powerOn --X:waitForIp --X:injectOvfEnv --X:enableHiddenProperties --prop:appliance.root_pwd='Admin!23' --prop:appliance.permit_root_login=True --net:"Network"="VM Network" ${ova_local_path} 'vi://administrator@vsphere.local:Admin!23@${target-vc-ip}${TEST_DATACENTER}/host/${ova-esx-host-ip}'
+    Log To Console  \novftool --datastore='${ova-esx-datastore}' --noSSLVerify --acceptAllEulas --name=${ova-name} --diskMode=thin --powerOn --X:waitForIp --X:injectOvfEnv --X:enableHiddenProperties --prop:appliance.root_pwd='Bl*ckwalnut0' --prop:appliance.permit_root_login=True --net:"Network"="VM Network" ${ova_local_path} 'vi://administrator@vsphere.local:Bl*ckwalnut0@${target-vc-ip}${TEST_DATACENTER}/host/${ova-esx-host-ip}'\n
+    ${output}=  Run  ovftool --datastore='${ova-esx-datastore}' --noSSLVerify --acceptAllEulas --name=${ova-name} --diskMode=thin --powerOn --X:waitForIp --X:injectOvfEnv --X:enableHiddenProperties --prop:appliance.root_pwd='Bl*ckwalnut0' --prop:appliance.permit_root_login=True --net:"Network"="VM Network" ${ova_local_path} 'vi://administrator@vsphere.local:Bl*ckwalnut0@${target-vc-ip}${TEST_DATACENTER}/host/${ova-esx-host-ip}'
     Should Contain  ${output}  Completed successfully
     Should Contain  ${output}  Received IP address:
 
@@ -272,7 +272,7 @@ Install VIC Product OVA
 
     Log To Console  \nWaiting for Getting Started Page to Come Up...
     :FOR  ${i}  IN RANGE  24
-    \   ${rc}  ${out}=  Run And Return Rc And Output  curl -k -w "\%{http_code}\\n" --header "Content-Type: application/json" -X POST --data '{"target":"${target-vc-ip}:443","user":"administrator@vsphere.local","password":"Admin!23"}' https://%{OVA_IP_${buildnum}}:9443/register 2>/dev/null
+    \   ${rc}  ${out}=  Run And Return Rc And Output  curl -k -w "\%{http_code}\\n" --header "Content-Type: application/json" -X POST --data '{"target":"${target-vc-ip}:443","user":"administrator@vsphere.local","password":"Bl*ckwalnut0"}' https://%{OVA_IP_${buildnum}}:9443/register 2>/dev/null
     \   Exit For Loop If  '200' in '''${out}'''
     \   Sleep  5s
     Log To Console  ${rc}

--- a/tests/test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/test-cases/Group18-VIC-UI/vicui-common.robot
@@ -350,7 +350,7 @@ Register Root CA Certificate With Windows
 Register VIC Machine Server CA With Windows
     [Arguments]  ${ova_ip}
     Log To Console  \nDownloading Root CA for VIC Machine server...
-    Open SSH Connection  ${ova_ip}  root  Admin\!23
+    Open SSH Connection  ${ova_ip}  root  Bl*ckwalnut0
     ${out}  ${rc}=  Execute Command  docker cp vic-machine-server:/certs/ca.crt /tmp/vic-machine-server-ca.crt  return_rc=True
     SSHLibrary.Get File  /tmp/vic-machine-server-ca.crt  /tmp/
     Close Connection
@@ -413,9 +413,15 @@ Deploy VC On Nimbus Async
 
 Configure Vcsa
     [Arguments]  ${name}  ${vc_fqdn}  ${esxi_list}
+    Open SSH Connection  ${vc_fqdn}  root  Admin\!23  retry_interval=30 sec
+    ${stdout}  ${rc}=  Execute Command  /usr/lib/vmware-vmafd/bin/dir-cli password change --account administrator@vsphere.local --current 'Admin!23' --new 'Bl*ckwalnut0' 2>&1  return_rc=True
+    Should Be Equal As Integers  ${rc}  0
+    Log To Console  ${stdout}
+    Close Connection
+
     Set Environment Variable  GOVC_INSECURE  1
     Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local
-    Set Environment Variable  GOVC_PASSWORD  Admin!23
+    Set Environment Variable  GOVC_PASSWORD  Bl*ckwalnut0
     Set Environment Variable  GOVC_URL  ${vc_fqdn}
 
     # create a datacenter


### PR DESCRIPTION
This PR makes several changes in our nightly test scripts in such a way that the vCenter Server Appliance and ESXi VMs are no longer served on our bare metal server, but created in Nimbus on demand. Lease is set to expire in one day so we can ensure each test environment is in a clean state.

**Update**
Combined work for issue 374 because it is closely related to this PR.

Fixes #337 #374 

PR acceptance checklist:

- [X] All unit tests pass
- [X] All e2e tests pass
- [n/a] Unit test(s) included*
- [n/a] e2e test(s) included*
- [n/a] Screenshot attached and UX approved*

 *if applicable, add n/a if not
 