### PR TITLE
Fix issue with networks population when host name contains some extra…

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.component.ts
@@ -156,16 +156,15 @@ export class ComputeCapacityComponent implements OnInit {
     let resourceObjForResourceAllocations = resourceObj;
 
     if (isCluster) {
-      computeResource = `${computeResource}/${payload.obj.text}`;
+      computeResource = `${computeResource}/${payload.obj.realName}`;
       resourceObjForResourceAllocations = payload.obj.aliases[0];
     } else {
       computeResource = payload.parentClusterObj ?
-        `${computeResource}/${payload.parentClusterObj.text}/${payload.obj.text}` :
-        `${computeResource}/${payload.obj.text}`;
+        `${computeResource}/${payload.parentClusterObj.text}/${payload.obj.realName}` :
+        `${computeResource}/${payload.obj.realName}`;
     }
-
     this.selectedResourceObjRef = resourceObj;
-    this.selectedObjectName = payload.obj.text;
+    this.selectedObjectName = payload.obj.realName;
     this._selectedComputeResource = computeResource;
 
     // set active class on the treenodecomponent whose datacenter object reference is

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.service.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.service.spec.ts
@@ -31,7 +31,9 @@ import { JASMINE_TIMEOUT } from '../testing/jasmine.constants';
 import { CreateVchWizardService } from './create-vch-wizard.service';
 import { Globals, GlobalsService } from '../shared';
 import {
-  dcDSwitchPorGroupsList, dvsHostsEntries,
+  computeResourcesRealName,
+  dcClustersAndStandAloneHosts,
+  dcDSwitchPorGroupsList, dcMockData, dvsHostsEntries,
   folderDSwitchList, folderDSwitchPorGroupsList,
   netWorkingResources
 } from './mocks/create-vch-wizard-mocked-data';
@@ -136,5 +138,20 @@ describe('CreateVchWizardService', () => {
           expect(data.length).toBe(3);
           });
 
-    })
+    });
+
+    it('should return a list of Compute Resources with a property called realName', async() => {
+      spyOn(service, 'getDatacenter').and.returnValue(Observable.of(dcMockData));
+      spyOn<any>(service, 'getDcClustersAndStandAloneHosts').and.returnValue(Observable.of(dcClustersAndStandAloneHosts));
+      spyOn<any>(service, 'getComputeResourceRealName').and.returnValue(Observable.of(computeResourcesRealName[0]));
+
+      service.getClustersList(null)
+        .subscribe(data => {
+          expect(data.length).toBe(1);
+          expect(data[0].realName).toBeTruthy();
+          expect(data[0].realName).toBe(computeResourcesRealName[0].name);
+        });
+
+    });
+
 });

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/mocks/create-vch-wizard-mocked-data.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/mocks/create-vch-wizard-mocked-data.ts
@@ -237,3 +237,36 @@ export const dvsHostsEntries = [
       ]}
   })
 ];
+
+export const dcMockData = [
+  {
+    text: 'ha-datacenter',
+    spriteCssClass: 'vsphere-icon-datacenter',
+    hasChildren: true,
+    objRef: 'urn:vmomi:Datacenter:datacenter-2:196f7764-7aec-42d8-9def-6b5899b7e0e1',
+    nodeTypeId: 'Datacenter',
+    aliases: [
+      'urn:vmomi:Folder:group-h4:196f7764-7aec-42d8-9def-6b5899b7e0e1',
+      'urn:vmomi:Folder:group-v3:196f7764-7aec-42d8-9def-6b5899b7e0e1',
+      'urn:vmomi:Folder:group-s5:196f7764-7aec-42d8-9def-6b5899b7e0e1',
+      'urn:vmomi:Folder:group-n6:196f7764-7aec-42d8-9def-6b5899b7e0e1']
+  }
+];
+
+export const dcClustersAndStandAloneHosts = [
+  {
+    text: '10.161.75.158 (Reboot Required)',
+    spriteCssClass: 'vsphere-icon-host-warning',
+    hasChildren: true,
+    objRef: 'urn:vmomi:HostSystem:host-15:196f7764-7aec-42d8-9def-6b5899b7e0e1',
+    nodeTypeId: 'DcStandaloneHost',
+    aliases: ['urn:vmomi:ResourcePool:resgroup-14:196f7764-7aec-42d8-9def-6b5899b7e0e1']
+  }
+];
+
+export const computeResourcesRealName = [
+  {
+    name: '10.161.75.158',
+    id: 'urn:vmomi:HostSystem:host-15:196f7764-7aec-42d8-9def-6b5899b7e0e1'
+  }
+];

--- a/h5c/vic/src/vic-webapp/src/app/interfaces/compute.resource.ts
+++ b/h5c/vic/src/vic-webapp/src/app/interfaces/compute.resource.ts
@@ -20,4 +20,5 @@ export interface ComputeResource {
   objRef: string;
   aliases: string[];
   isEmpty: boolean;
+  realName?: string;
 }


### PR DESCRIPTION
This commit will fix an error produced when hosts contains some extra text on the name added by the vc like '(reboot required)'

Fixes #423 

PR acceptance checklist:

[ x ] All unit tests pass
[ x ] All e2e tests pass
[ n/a ] Unit test(s) included*
[ n/a ] e2e test(s) included*
[ n/a ] Screenshot attached and UX approved*

![423-fix](https://user-images.githubusercontent.com/36636787/39011688-8cfd7332-43e8-11e8-8197-ce3d964d4262.gif)

