### PR TITLE
Use the most recent reachable tag during build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -54,7 +54,7 @@ pipeline:
       - 'mkdir bundle'
       - 'mkdir bundle-release'
       - 'cp $BIN/vic_ui_${DRONE_BUILD_NUMBER}.tar.gz bundle'
-      - 'cp $BIN/vic_ui_${DRONE_BUILD_NUMBER}.tar.gz bundle-release/vic_ui_`git describe --tags $(git rev-list --tags --max-count=1)`.tar.gz'
+      - 'cp $BIN/vic_ui_${DRONE_BUILD_NUMBER}.tar.gz bundle-release/vic_ui_`git describe --tags --abbrev=0`.tar.gz'
       - 'rm -rf $BIN'
       - 'ls -la bundle'
     when:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y openjdk-7-jdk maven ant ant-optional google-chrome-stable yarn=0.24.6-1
   - export PATH=/usr/share/yarn/bin:$PATH
-  - export TAG=$(git for-each-ref --format="%(refname:short)" --sort=authordate --count=1 refs/tags)
-  - export TAG_NUM=$(git for-each-ref --format="%(refname:short)" --sort=-authordate --count=1 refs/tags | cut -c 2-)
+  - export TAG=$(git describe --tags --abbrev=0)
+  - export TAG_NUM=$(git describe --tags --abbrev=0 | cut -c 2-)
 branches:
   only:
     - new-master


### PR DESCRIPTION
When determining which tag to use during the build process, use the most recent tag that is reachable from the current commit instead of the most recent tag in the repository.

Include `--tags` to enable matching on lightweight tags.

Include `--abbrev=0` to suppress the long format (which includes an offset and abbreviated hash) and show only the closest tag.

Towards: vmware/vic-product#1206