### PR TITLE
Fix issue with empty and or duplicated nodes on resource tree selector

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.html
@@ -23,23 +23,24 @@
                 {{ serverInfo['name'] }}
             </button>
             <ng-template [clrIfExpanded]="true">
-              <clr-tree-node class="form-control"
-                           [class.invalid]="form.invalid && form.getError('invalidComputeResource')"
-                           [clrLoading]="isTreeLoading"
-                           *ngFor="let dc of datacenter">
-                  <button class="clr-treenode-link"
-                          *ngIf="dc.objRef.indexOf(serverInfo.serviceGuid) > -1">
-                    <clr-icon shape="building"></clr-icon>
-                    {{ dc.text }}
-                  </button>
-                  <ng-template [clrIfExpanded]="true">
-                    <vic-compute-resource-treenode #crTreenode
-                                                    [serverInfo]="serverInfo"
-                                                    [datacenter]="dc"
-                                                    (resourceSelected)="selectComputeResource($event)">
-                    </vic-compute-resource-treenode>
-                  </ng-template>
-              </clr-tree-node>
+              <ng-container *ngFor="let dc of datacenter">
+                <clr-tree-node class="form-control"
+                               [class.invalid]="form.invalid && form.getError('invalidComputeResource')"
+                               [clrLoading]="isTreeLoading"
+                               *ngIf="dc.objRef.indexOf(serverInfo.serviceGuid) > -1">
+                    <button class="clr-treenode-link">
+                      <clr-icon shape="building"></clr-icon>
+                      {{ dc.text }}
+                    </button>
+                    <ng-template [clrIfExpanded]="true">
+                      <vic-compute-resource-treenode #crTreenode
+                                                      [serverInfo]="serverInfo"
+                                                      [datacenter]="dc"
+                                                      (resourceSelected)="selectComputeResource($event)">
+                      </vic-compute-resource-treenode>
+                    </ng-template>
+                </clr-tree-node>
+              </ng-container>
             </ng-template>
           </clr-tree-node>
         </ng-container>

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.template.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.template.html
@@ -1,9 +1,9 @@
 <!-- Copyright 2017-2018 VMware, Inc. All Rights Reserved. -->
-      <!-- cluster and clusterhostsystems -->
-      <clr-tree-node *ngFor="let cluster of clusters"
-                     [clrLoading]="loading">
-        <button #btnEl class="clr-treenode-link cc-resource"
-                *ngIf="!cluster.isEmpty"
+<!-- cluster and clusterhostsystems -->
+  <ng-container *ngFor="let cluster of clusters">
+      <clr-tree-node *ngIf="!cluster.isEmpty" [clrLoading]="loading">
+        <button #btnEl
+                class="clr-treenode-link cc-resource"
                 (click)="selectResource($event, cluster)">
           <clr-icon shape="cluster"></clr-icon>
           {{ cluster['text'] }}
@@ -20,12 +20,13 @@
           </ng-container>
         </ng-template>
       </clr-tree-node>
+  </ng-container>
 
-      <!-- standalone hosts -->
-      <clr-tree-node *ngFor="let host of standaloneHosts">
-        <button #btnEl class="clr-treenode-link cc-resource"
-                (click)="selectResource($event, host)">
-          <clr-icon shape="host"></clr-icon>
-          {{ host['text'] }}
-        </button>
-      </clr-tree-node>
+  <!-- standalone hosts -->
+  <clr-tree-node *ngFor="let host of standaloneHosts">
+    <button #btnEl class="clr-treenode-link cc-resource"
+            (click)="selectResource($event, host)">
+      <clr-icon shape="host"></clr-icon>
+      {{ host['text'] }}
+    </button>
+  </clr-tree-node>


### PR DESCRIPTION
Fix issue with empty and or duplicated nodes on resource tree selector of vch creation wizard

Fixes #441 

PR acceptance checklist:

[ x ] All unit tests pass
[ x ] All e2e tests pass
[ n/a ] Unit test(s) included*
[ n/a ] e2e test(s) included*
[ n/a ] Screenshot attached and UX approved*

Screenshots attached of before and after for multivc and singlevc:

singlevc structure:
<img width="1843" alt="singlevc-441-structure" src="https://user-images.githubusercontent.com/36636787/39152633-56d5c9b4-471f-11e8-980f-a3da3373bc50.png">

singlevc before this fix:
![singlevc-441-before](https://user-images.githubusercontent.com/36636787/39152601-3f920f2e-471f-11e8-957c-a407d20d9cfb.gif)

singlevc after this fix:
![singlevc-441-after](https://user-images.githubusercontent.com/36636787/39152618-4d0c394a-471f-11e8-94ed-8b58cee8e790.gif)

multivc structure:
<img width="407" alt="multivc-441-structure" src="https://user-images.githubusercontent.com/36636787/39152651-62c80e9e-471f-11e8-8031-12adb9c4e7cf.png">

multivc before this fix:
![multivc-441-before](https://user-images.githubusercontent.com/36636787/39152663-69bc4eea-471f-11e8-9459-567ede97579c.gif)

multivc after this fix:
![multivc-441-after](https://user-images.githubusercontent.com/36636787/39152678-71be0868-471f-11e8-8b83-aa59aa4fc321.gif)

