### PR TITLE
Introduce a VCH Configure Menu under the Configure view

### DIFF
--- a/h5c/vic/src/main/webapp/plugin.xml
+++ b/h5c/vic/src/main/webapp/plugin.xml
@@ -289,4 +289,142 @@
             </propertyConditions>
       </metadata>
    </extension>
+
+    <!-- VCH VM Configure Left Nav Category -->
+    <extension id="com.vmware.vic.vchConfigureCategory">
+        <extendedPoint>vsphere.core.vm.manageCategories</extendedPoint>
+        <object>
+            <label>Virtual Container Host</label>
+        </object>
+        <metadata>
+            <objectType>VirtualMachine</objectType>
+            <propertyConditions>
+                <com.vmware.data.query.CompositeConstraint>
+                    <nestedConstraints>
+                        <com.vmware.data.query.PropertyConstraint>
+                            <propertyName>isVCH</propertyName>
+                            <comparator>EQUALS</comparator>
+                            <comparableValue>
+                                <Boolean>true</Boolean>
+                            </comparableValue>
+                        </com.vmware.data.query.PropertyConstraint>
+                    </nestedConstraints>
+                    <conjoiner>AND</conjoiner>
+                </com.vmware.data.query.CompositeConstraint>
+            </propertyConditions>
+        </metadata>
+    </extension>
+
+    <!-- VCH VM Configure General -->
+    <extension id="com.vmware.vic.vchConfigureGeneral">
+        <extendedPoint>vsphere.core.vm.manageViews</extendedPoint>
+        <object>
+            <name>General</name>
+            <categoryUid>com.vmware.vic.vchConfigureCategory</categoryUid>
+            <componentClass className="com.vmware.vsphere.client.htmlbridge.HtmlView">
+                <object>
+                    <root>
+                        <url>/vsphere-client/vic/resources/dist/index.html?view=configure-vch-view-general</url>
+                    </root>
+                </object>
+            </componentClass>
+        </object>
+    </extension>
+
+    <!-- VCH VM Configure Compute -->
+    <extension id="com.vmware.vic.vchConfigureCompute">
+        <extendedPoint>vsphere.core.vm.manageViews</extendedPoint>
+        <object>
+            <name>Compute Capacity</name>
+            <categoryUid>com.vmware.vic.vchConfigureCategory</categoryUid>
+            <componentClass className="com.vmware.vsphere.client.htmlbridge.HtmlView">
+                <object>
+                    <root>
+                        <url>/vsphere-client/vic/resources/dist/index.html?view=configure-vch-view-compute</url>
+                    </root>
+                </object>
+            </componentClass>
+        </object>
+    </extension>
+
+    <!-- VCH VM Configure Storage -->
+    <extension id="com.vmware.vic.vchConfigureStorage">
+        <extendedPoint>vsphere.core.vm.manageViews</extendedPoint>
+        <object>
+            <name>Storage Capacity</name>
+            <categoryUid>com.vmware.vic.vchConfigureCategory</categoryUid>
+            <componentClass className="com.vmware.vsphere.client.htmlbridge.HtmlView">
+                <object>
+                    <root>
+                        <url>/vsphere-client/vic/resources/dist/index.html?view=configure-vch-view-storage</url>
+                    </root>
+                </object>
+            </componentClass>
+        </object>
+    </extension>
+
+    <!-- VCH VM Configure Network -->
+    <extension id="com.vmware.vic.vchConfigureNetwork">
+        <extendedPoint>vsphere.core.vm.manageViews</extendedPoint>
+        <object>
+            <name>Network</name>
+            <categoryUid>com.vmware.vic.vchConfigureCategory</categoryUid>
+            <componentClass className="com.vmware.vsphere.client.htmlbridge.HtmlView">
+                <object>
+                    <root>
+                        <url>/vsphere-client/vic/resources/dist/index.html?view=configure-vch-view-network</url>
+                    </root>
+                </object>
+            </componentClass>
+        </object>
+    </extension>
+
+    <!-- VCH VM Configure Security -->
+    <extension id="com.vmware.vic.vchConfigureSecurity">
+        <extendedPoint>vsphere.core.vm.manageViews</extendedPoint>
+        <object>
+            <name>Security</name>
+            <categoryUid>com.vmware.vic.vchConfigureCategory</categoryUid>
+            <componentClass className="com.vmware.vsphere.client.htmlbridge.HtmlView">
+                <object>
+                    <root>
+                        <url>/vsphere-client/vic/resources/dist/index.html?view=configure-vch-view-security</url>
+                    </root>
+                </object>
+            </componentClass>
+        </object>
+    </extension>
+
+    <!-- VCH VM Configure Registry -->
+    <extension id="com.vmware.vic.vchConfigureRegistry">
+        <extendedPoint>vsphere.core.vm.manageViews</extendedPoint>
+        <object>
+            <name>Registry Access</name>
+            <categoryUid>com.vmware.vic.vchConfigureCategory</categoryUid>
+            <componentClass className="com.vmware.vsphere.client.htmlbridge.HtmlView">
+                <object>
+                    <root>
+                        <url>/vsphere-client/vic/resources/dist/index.html?view=configure-vch-view-registry</url>
+                    </root>
+                </object>
+            </componentClass>
+        </object>
+    </extension>
+
+    <!-- VCH VM Configure User -->
+    <extension id="com.vmware.vic.vchConfigureOperations">
+        <extendedPoint>vsphere.core.vm.manageViews</extendedPoint>
+        <object>
+            <name>Operations User</name>
+            <categoryUid>com.vmware.vic.vchConfigureCategory</categoryUid>
+            <componentClass className="com.vmware.vsphere.client.htmlbridge.HtmlView">
+                <object>
+                    <root>
+                        <url>/vsphere-client/vic/resources/dist/index.html?view=configure-vch-view-operations</url>
+                    </root>
+                </object>
+            </componentClass>
+        </object>
+    </extension>
+
 </plugin>

--- a/h5c/vic/src/vic-webapp/src/app/app-routing.module.ts
+++ b/h5c/vic/src/vic-webapp/src/app/app-routing.module.ts
@@ -27,6 +27,34 @@ const appRoutes: Routes = [
     { path: 'vch-view', loadChildren: './vch-view/vch-view.module#VicVchViewModule' },
     { path: 'container-view', loadChildren: './container-view/container-view.module#VicContainerViewModule' },
     { path: 'create-vch', loadChildren: './create-vch-wizard/create-vch-wizard.module#CreateVchWizardModule' },
+    {
+      path: 'configure-vch-view-general',
+      loadChildren: './configure/configure-vch-view/general/configure-vch-view-general.module#ConfigureVchViewGeneralModule'
+    },
+    {
+      path: 'configure-vch-view-compute',
+      loadChildren: './configure/configure-vch-view/compute/configure-vch-view-compute.module#ConfigureVchViewComputeModule'
+    },
+    {
+      path: 'configure-vch-view-network',
+      loadChildren: './configure/configure-vch-view/network/configure-vch-view-network.module#ConfigureVchViewNetworkModule'
+    },
+    {
+      path: 'configure-vch-view-operations',
+      loadChildren: './configure/configure-vch-view/operations/configure-vch-view-operations.module#ConfigureVchViewOperationsModule'
+    },
+    {
+      path: 'configure-vch-view-registry',
+      loadChildren: './configure/configure-vch-view/registry/configure-vch-view-registry.module#ConfigureVchViewRegistryModule'
+    },
+    {
+      path: 'configure-vch-view-security',
+      loadChildren: './configure/configure-vch-view/security/configure-vch-view-security.module#ConfigureVchViewSecurityModule'
+    },
+    {
+      path: 'configure-vch-view-storage',
+      loadChildren: './configure/configure-vch-view/storage/configure-vch-view-storage.module#ConfigureVchViewStorageModule'
+    },
     { path: 'delete-vch', loadChildren: './delete-vch-modal/delete-vch-modal.module#DeleteVchModalModule' },
     { path: 'ui-actions', loadChildren: './ui-actions/ui-actions.module#UiActionsModule' }
 ];

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/compute/configure-vch-view-compute.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/compute/configure-vch-view-compute.component.html
@@ -1,0 +1,1 @@
+Compute

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/compute/configure-vch-view-compute.component.scss
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/compute/configure-vch-view-compute.component.scss
@@ -1,0 +1,15 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/compute/configure-vch-view-compute.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/compute/configure-vch-view-compute.component.ts
@@ -1,0 +1,27 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'vic-configure-vch-view-compute',
+  styleUrls: ['./configure-vch-view-compute.component.scss'],
+  templateUrl: './configure-vch-view-compute.component.html'
+})
+
+export class ConfigureVchViewComputeComponent {
+
+}

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/compute/configure-vch-view-compute.module.ts
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/compute/configure-vch-view-compute.module.ts
@@ -1,0 +1,39 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterModule, Routes} from '@angular/router';
+import {ClarityModule} from '@clr/angular';
+import {ConfigureVchViewComputeComponent} from './configure-vch-view-compute.component';
+
+const routes: Routes = [
+  {path: '', component: ConfigureVchViewComputeComponent},
+  {path: ':id', component: ConfigureVchViewComputeComponent}
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ClarityModule,
+    RouterModule.forChild(routes)
+  ],
+  declarations: [
+    ConfigureVchViewComputeComponent
+  ],
+  exports: [ConfigureVchViewComputeComponent]
+})
+export class ConfigureVchViewComputeModule {
+}

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/general/configure-vch-view-general.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/general/configure-vch-view-general.component.html
@@ -1,0 +1,1 @@
+General

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/general/configure-vch-view-general.component.scss
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/general/configure-vch-view-general.component.scss
@@ -1,0 +1,15 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/general/configure-vch-view-general.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/general/configure-vch-view-general.component.ts
@@ -1,0 +1,27 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'vic-configure-vch-view-general',
+  styleUrls: ['./configure-vch-view-general.component.scss'],
+  templateUrl: './configure-vch-view-general.component.html'
+})
+
+export class ConfigureVchViewGeneralComponent {
+
+}

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/general/configure-vch-view-general.module.ts
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/general/configure-vch-view-general.module.ts
@@ -1,0 +1,39 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterModule, Routes} from '@angular/router';
+import {ClarityModule} from '@clr/angular';
+import {ConfigureVchViewGeneralComponent} from './configure-vch-view-general.component';
+
+const routes: Routes = [
+  {path: '', component: ConfigureVchViewGeneralComponent},
+  {path: ':id', component: ConfigureVchViewGeneralComponent}
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ClarityModule,
+    RouterModule.forChild(routes)
+  ],
+  declarations: [
+    ConfigureVchViewGeneralComponent
+  ],
+  exports: [ConfigureVchViewGeneralComponent]
+})
+export class ConfigureVchViewGeneralModule {
+}

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/network/configure-vch-view-network.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/network/configure-vch-view-network.component.html
@@ -1,0 +1,1 @@
+Network

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/network/configure-vch-view-network.component.scss
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/network/configure-vch-view-network.component.scss
@@ -1,0 +1,15 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/network/configure-vch-view-network.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/network/configure-vch-view-network.component.ts
@@ -1,0 +1,27 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'vic-configure-vch-view-network',
+  styleUrls: ['./configure-vch-view-network.component.scss'],
+  templateUrl: './configure-vch-view-network.component.html'
+})
+
+export class ConfigureVchViewNetworkComponent {
+
+}

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/network/configure-vch-view-network.module.ts
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/network/configure-vch-view-network.module.ts
@@ -1,0 +1,39 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterModule, Routes} from '@angular/router';
+import {ClarityModule} from '@clr/angular';
+import {ConfigureVchViewNetworkComponent} from './configure-vch-view-network.component';
+
+const routes: Routes = [
+  {path: '', component: ConfigureVchViewNetworkComponent},
+  {path: ':id', component: ConfigureVchViewNetworkComponent}
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ClarityModule,
+    RouterModule.forChild(routes)
+  ],
+  declarations: [
+    ConfigureVchViewNetworkComponent
+  ],
+  exports: [ConfigureVchViewNetworkComponent]
+})
+export class ConfigureVchViewNetworkModule {
+}

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/operations/configure-vch-view-operations.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/operations/configure-vch-view-operations.component.html
@@ -1,0 +1,1 @@
+Operations

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/operations/configure-vch-view-operations.component.scss
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/operations/configure-vch-view-operations.component.scss
@@ -1,0 +1,15 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/operations/configure-vch-view-operations.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/operations/configure-vch-view-operations.component.ts
@@ -1,0 +1,27 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'vic-configure-vch-view-operations',
+  styleUrls: ['./configure-vch-view-operations.component.scss'],
+  templateUrl: './configure-vch-view-operations.component.html'
+})
+
+export class ConfigureVchViewOperationsComponent {
+
+}

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/operations/configure-vch-view-operations.module.ts
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/operations/configure-vch-view-operations.module.ts
@@ -1,0 +1,39 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterModule, Routes} from '@angular/router';
+import {ClarityModule} from '@clr/angular';
+import {ConfigureVchViewOperationsComponent} from './configure-vch-view-operations.component';
+
+const routes: Routes = [
+  {path: '', component: ConfigureVchViewOperationsComponent},
+  {path: ':id', component: ConfigureVchViewOperationsComponent}
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ClarityModule,
+    RouterModule.forChild(routes)
+  ],
+  declarations: [
+    ConfigureVchViewOperationsComponent
+  ],
+  exports: [ConfigureVchViewOperationsComponent]
+})
+export class ConfigureVchViewOperationsModule {
+}

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/registry/configure-vch-view-registry.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/registry/configure-vch-view-registry.component.html
@@ -1,0 +1,1 @@
+Registry

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/registry/configure-vch-view-registry.component.scss
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/registry/configure-vch-view-registry.component.scss
@@ -1,0 +1,15 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/registry/configure-vch-view-registry.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/registry/configure-vch-view-registry.component.ts
@@ -1,0 +1,27 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'vic-configure-vch-view-registry',
+  styleUrls: ['./configure-vch-view-registry.component.scss'],
+  templateUrl: './configure-vch-view-registry.component.html'
+})
+
+export class ConfigureVchViewRegistryComponent {
+
+}

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/registry/configure-vch-view-registry.module.ts
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/registry/configure-vch-view-registry.module.ts
@@ -1,0 +1,39 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterModule, Routes} from '@angular/router';
+import {ClarityModule} from '@clr/angular';
+import {ConfigureVchViewRegistryComponent} from './configure-vch-view-registry.component';
+
+const routes: Routes = [
+  {path: '', component: ConfigureVchViewRegistryComponent},
+  {path: ':id', component: ConfigureVchViewRegistryComponent}
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ClarityModule,
+    RouterModule.forChild(routes)
+  ],
+  declarations: [
+    ConfigureVchViewRegistryComponent
+  ],
+  exports: [ConfigureVchViewRegistryComponent]
+})
+export class ConfigureVchViewRegistryModule {
+}

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/security/configure-vch-view-security.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/security/configure-vch-view-security.component.html
@@ -1,0 +1,1 @@
+Security

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/security/configure-vch-view-security.component.scss
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/security/configure-vch-view-security.component.scss
@@ -1,0 +1,15 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/security/configure-vch-view-security.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/security/configure-vch-view-security.component.ts
@@ -1,0 +1,27 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'vic-configure-vch-view-security',
+  styleUrls: ['./configure-vch-view-security.component.scss'],
+  templateUrl: './configure-vch-view-security.component.html'
+})
+
+export class ConfigureVchViewSecurityComponent {
+
+}

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/security/configure-vch-view-security.module.ts
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/security/configure-vch-view-security.module.ts
@@ -1,0 +1,39 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterModule, Routes} from '@angular/router';
+import {ClarityModule} from '@clr/angular';
+import {ConfigureVchViewSecurityComponent} from './configure-vch-view-security.component';
+
+const routes: Routes = [
+  {path: '', component: ConfigureVchViewSecurityComponent},
+  {path: ':id', component: ConfigureVchViewSecurityComponent}
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ClarityModule,
+    RouterModule.forChild(routes)
+  ],
+  declarations: [
+    ConfigureVchViewSecurityComponent
+  ],
+  exports: [ConfigureVchViewSecurityComponent]
+})
+export class ConfigureVchViewSecurityModule {
+}

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/storage/configure-vch-view-storage.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/storage/configure-vch-view-storage.component.html
@@ -1,0 +1,1 @@
+Storage

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/storage/configure-vch-view-storage.component.scss
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/storage/configure-vch-view-storage.component.scss
@@ -1,0 +1,15 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/storage/configure-vch-view-storage.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/storage/configure-vch-view-storage.component.ts
@@ -1,0 +1,27 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'vic-configure-vch-view-storage',
+  styleUrls: ['./configure-vch-view-storage.component.scss'],
+  templateUrl: './configure-vch-view-storage.component.html'
+})
+
+export class ConfigureVchViewStorageComponent {
+
+}

--- a/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/storage/configure-vch-view-storage.module.ts
+++ b/h5c/vic/src/vic-webapp/src/app/configure/configure-vch-view/storage/configure-vch-view-storage.module.ts
@@ -1,0 +1,39 @@
+/*
+ Copyright 2018 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterModule, Routes} from '@angular/router';
+import {ClarityModule} from '@clr/angular';
+import {ConfigureVchViewStorageComponent} from './configure-vch-view-storage.component';
+
+const routes: Routes = [
+  {path: '', component: ConfigureVchViewStorageComponent},
+  {path: ':id', component: ConfigureVchViewStorageComponent}
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ClarityModule,
+    RouterModule.forChild(routes)
+  ],
+  declarations: [
+    ConfigureVchViewStorageComponent
+  ],
+  exports: [ConfigureVchViewStorageComponent]
+})
+export class ConfigureVchViewStorageModule {
+}


### PR DESCRIPTION
This change will introduce a brand new VCH Configure Menu on each VCH VM. This menu will bring individual access to each of the VCH Configure stpes in order to allow user to view and reconfigure only a particular step related with the VCH configuration.

Fixes #391 

PR acceptance checklist:

[ x ] All unit tests pass
[ x ] All e2e tests pass
[ n/a ] Unit test(s) included*
[ n/a ] e2e test(s) included*
[ x ] Screenshot attached and UX approved*

 Configure for regular VM
<img width="1373" alt="regular-vm" src="https://user-images.githubusercontent.com/36636787/39598743-fc2687d2-4eef-11e8-80bf-ba12fd9c4b6a.png">

Configure for VCH VM
![vch-vm](https://user-images.githubusercontent.com/36636787/39598744-fc4e6180-4eef-11e8-837e-5f1f1e3b9656.gif)


