### PR TITLE
Cherry-pick: Fix issue with empty and or duplicated nodes on resource tree selector of vch creation wizard (#448)

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.html
@@ -23,23 +23,24 @@
                 {{ serverInfo['name'] }}
             </button>
             <ng-template [clrIfExpanded]="true">
-              <clr-tree-node class="form-control"
-                           [class.invalid]="form.invalid && form.getError('invalidComputeResource')"
-                           [clrLoading]="isTreeLoading"
-                           *ngFor="let dc of datacenter">
-                  <button class="clr-treenode-link"
-                          *ngIf="dc.objRef.indexOf(serverInfo.serviceGuid) > -1">
-                    <clr-icon shape="building"></clr-icon>
-                    {{ dc.text }}
-                  </button>
-                  <ng-template [clrIfExpanded]="true">
-                    <vic-compute-resource-treenode #crTreenode
-                                                    [serverInfo]="serverInfo"
-                                                    [datacenter]="dc"
-                                                    (resourceSelected)="selectComputeResource($event)">
-                    </vic-compute-resource-treenode>
-                  </ng-template>
-              </clr-tree-node>
+              <ng-container *ngFor="let dc of datacenter">
+                <clr-tree-node class="form-control"
+                               [class.invalid]="form.invalid && form.getError('invalidComputeResource')"
+                               [clrLoading]="isTreeLoading"
+                               *ngIf="dc.objRef.indexOf(serverInfo.serviceGuid) > -1">
+                    <button class="clr-treenode-link">
+                      <clr-icon shape="building"></clr-icon>
+                      {{ dc.text }}
+                    </button>
+                    <ng-template [clrIfExpanded]="true">
+                      <vic-compute-resource-treenode #crTreenode
+                                                      [serverInfo]="serverInfo"
+                                                      [datacenter]="dc"
+                                                      (resourceSelected)="selectComputeResource($event)">
+                      </vic-compute-resource-treenode>
+                    </ng-template>
+                </clr-tree-node>
+              </ng-container>
             </ng-template>
           </clr-tree-node>
         </ng-container>

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.template.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.template.html
@@ -1,9 +1,9 @@
 <!-- Copyright 2017-2018 VMware, Inc. All Rights Reserved. -->
-      <!-- cluster and clusterhostsystems -->
-      <clr-tree-node *ngFor="let cluster of clusters"
-                     [clrLoading]="loading">
-        <button #btnEl class="clr-treenode-link cc-resource"
-                *ngIf="!cluster.isEmpty"
+<!-- cluster and clusterhostsystems -->
+  <ng-container *ngFor="let cluster of clusters">
+      <clr-tree-node *ngIf="!cluster.isEmpty" [clrLoading]="loading">
+        <button #btnEl
+                class="clr-treenode-link cc-resource"
                 (click)="selectResource($event, cluster)">
           <clr-icon shape="cluster"></clr-icon>
           {{ cluster['text'] }}
@@ -20,12 +20,13 @@
           </ng-container>
         </ng-template>
       </clr-tree-node>
+  </ng-container>
 
-      <!-- standalone hosts -->
-      <clr-tree-node *ngFor="let host of standaloneHosts">
-        <button #btnEl class="clr-treenode-link cc-resource"
-                (click)="selectResource($event, host)">
-          <clr-icon shape="host"></clr-icon>
-          {{ host['text'] }}
-        </button>
-      </clr-tree-node>
+  <!-- standalone hosts -->
+  <clr-tree-node *ngFor="let host of standaloneHosts">
+    <button #btnEl class="clr-treenode-link cc-resource"
+            (click)="selectResource($event, host)">
+      <clr-icon shape="host"></clr-icon>
+      {{ host['text'] }}
+    </button>
+  </clr-tree-node>


### PR DESCRIPTION
Fixes #441 

