### PR TITLE
Cherry-pick: Use the most recent reachable tag during build (#443)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -54,7 +54,7 @@ pipeline:
       - 'mkdir bundle'
       - 'mkdir bundle-release'
       - 'cp $BIN/vic_ui_${DRONE_BUILD_NUMBER}.tar.gz bundle'
-      - 'cp $BIN/vic_ui_${DRONE_BUILD_NUMBER}.tar.gz bundle-release/vic_ui_`git describe --tags $(git rev-list --tags --max-count=1)`.tar.gz'
+      - 'cp $BIN/vic_ui_${DRONE_BUILD_NUMBER}.tar.gz bundle-release/vic_ui_`git describe --tags --abbrev=0`.tar.gz'
       - 'rm -rf $BIN'
       - 'ls -la bundle'
     when:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y openjdk-7-jdk maven ant ant-optional google-chrome-stable yarn=0.24.6-1
   - export PATH=/usr/share/yarn/bin:$PATH
-  - export TAG=$(git for-each-ref --format="%(refname:short)" --sort=authordate --count=1 refs/tags)
-  - export TAG_NUM=$(git for-each-ref --format="%(refname:short)" --sort=-authordate --count=1 refs/tags | cut -c 2-)
+  - export TAG=$(git describe --tags --abbrev=0)
+  - export TAG_NUM=$(git describe --tags --abbrev=0 | cut -c 2-)
 branches:
   only:
     - new-master


### PR DESCRIPTION
Fixes #443 