### PR TITLE
Introduce a VCH Reconfigure datagrid action on Virtual Container Hosts view

### DIFF
--- a/h5c/vic/src/main/locale/en_US/com_vmware_vic.properties
+++ b/h5c/vic/src/main/locale/en_US/com_vmware_vic.properties
@@ -25,6 +25,10 @@ vic_workspace.vch.datagrid.columns.overallStatus=Status
 vic_workspace.vch.datagrid.columns.dockerApiEndpoint=Docker API Endpoint
 vic_workspace.vch.datagrid.columns.vchAdminPortal=VCH Admin Portal
 vic_workspace.vch.datagrid.msg.waitingForIp=Waiting...
+vic_workspace.vch.datagrid.msg.newVch=New Virtual Container Host
+vic_workspace.vch.datagrid.actionMenu.reconfigureLink=Reconfigure Virtual Container Host
+vic_workspace.vch.datagrid.actionMenu.delete=Delete Virtual Container Host
+vic_workspace.vch.datagrid.actionMenu.downloadCert=Download VCH certificate
 
 # vic object workspace: container view
 vic_workspace.container.tab.label=Containers
@@ -36,6 +40,8 @@ vic_workspace.container.datagrid.columns.committedStorage=Storage Usage
 vic_workspace.container.datagrid.columns.portMapping=Port Mapping
 vic_workspace.container.datagrid.columns.name=VM
 vic_workspace.container.datagrid.columns.imageName=Image
+
+
 
 # vch compute capacity
 vch.computeCapacity.vmHostAffinity.title=VM-Host Affinity

--- a/h5c/vic/src/vic-webapp/src/app/shared/constants/resources.path.ts
+++ b/h5c/vic/src/vic-webapp/src/app/shared/constants/resources.path.ts
@@ -16,6 +16,7 @@
 
 export const VIC_LOGO_100X100 = '/assets/vic-icons/100x100.png';
 export const VSPHERE_VM_SUMMARY_KEY = 'vsphere.core.vm.summary';
+export const VSPHERE_VIC_CONFIGURE_GENERAL_KEY = 'com.vmware.vic.vchConfigureGeneral';
 export const VSPHERE_SERVEROBJ_VIEWEXT_KEY =
     'vsphere.core.inventory.serverObjectViewsExtension';
 export const VSPHERE_VITREE_HOSTCLUSTERVIEW_KEY =
@@ -57,10 +58,24 @@ export const WS_VCH = {
         },
         MESSAGES: {
           keys: {
-            WAITING_FOR_IP: 'vic_workspace.vch.datagrid.msg.waitingForIp'
+            WAITING_FOR_IP: 'vic_workspace.vch.datagrid.msg.waitingForIp',
+            NEW: 'vic_workspace.vch.datagrid.msg.newVch'
           },
           defaults: {
-            'vic_workspace.vch.datagrid.msg.waitingForIp': 'Waiting...'
+            'vic_workspace.vch.datagrid.msg.waitingForIp': 'Waiting...',
+            'vic_workspace.vch.datagrid.msg.newVch': 'New Virtual Container Host'
+          }
+        },
+        ACTIONS: {
+          keys: {
+            DOWNLOAD_CERT: 'vic_workspace.vch.datagrid.actionMenu.downloadCert',
+            RECONFIGURE: 'vic_workspace.vch.datagrid.actionMenu.reconfigureLink',
+            DELETE: 'vic_workspace.vch.datagrid.actionMenu.delete'
+          },
+          defaults: {
+            'vic_workspace.vch.datagrid.actionMenu.downloadCert': 'Download VCH certificate',
+            'vic_workspace.vch.datagrid.actionMenu.reconfigureLink': 'Reconfigure Virtual Container Host',
+            'vic_workspace.vch.datagrid.actionMenu.delete': 'Delete Virtual Container Host'
           }
         }
     }

--- a/h5c/vic/src/vic-webapp/src/app/vch-view/vch-view.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/vch-view/vch-view.component.ts
@@ -26,7 +26,7 @@ import {
   DOCKER_ENGINE_PORT_NOTLS,
   DOCKER_ENGINE_PORT_TLS,
   VIC_ROOT_OBJECT_ID_WITH_NAME,
-  VSPHERE_SERVEROBJ_VIEWEXT_KEY,
+  VSPHERE_SERVEROBJ_VIEWEXT_KEY, VSPHERE_VIC_CONFIGURE_GENERAL_KEY,
   VSPHERE_VITREE_HOSTCLUSTERVIEW_KEY,
   VSPHERE_VM_SUMMARY_KEY,
   WIZARD_MODAL_HEIGHT,
@@ -64,6 +64,7 @@ import { getServerInfoByVchObjRef } from '../shared/utils/object-reference';
 })
 export class VicVchViewComponent implements OnInit, OnDestroy, AfterViewInit {
   public readonly WS_VCH_CONSTANTS = WS_VCH;
+  public readonly VIC_CONFIGURE_GENERAL_KEY = VSPHERE_VIC_CONFIGURE_GENERAL_KEY;
   private refreshSubscription: Subscription;
   public isDgLoading = true;
   public vchs: VirtualContainerHost[] = [];
@@ -199,10 +200,10 @@ export class VicVchViewComponent implements OnInit, OnDestroy, AfterViewInit {
    * Navigates to an object specified by objectId
    * @param objectId Full vSphere objectId which starts with urn:
    */
-  navigateToObject(objectId: string) {
+  navigateToObject(objectId: string, key: string = VSPHERE_VM_SUMMARY_KEY) {
     if (objectId.indexOf('VirtualMachine') > -1) {
       this.globalsService.getWebPlatform().sendNavigationRequest(
-        VSPHERE_VM_SUMMARY_KEY, objectId);
+        key, objectId);
     } else {
       window.parent.location.href = '/ui/#?extensionId=' +
         VSPHERE_SERVEROBJ_VIEWEXT_KEY + '&' +

--- a/h5c/vic/src/vic-webapp/src/app/vch-view/vch-view.template.html
+++ b/h5c/vic/src/vic-webapp/src/app/vch-view/vch-view.template.html
@@ -31,7 +31,7 @@
 <clr-datagrid (clrDgRefresh)="refreshGrid($event)" [clrDgLoading]="isDgLoading">
   <clr-dg-action-bar>
     <button class="btn btn-link btn-sm new-vch" (click)="launchCreateVchWizard()">
-      <clr-icon shape="add"></clr-icon> New Virtual Container Host
+      <clr-icon shape="add"></clr-icon> {{vicI18n.translate(this.WS_VCH_CONSTANTS.DG.MESSAGES, 'NEW')}}
     </button>
   </clr-dg-action-bar>
   <clr-dg-column [clrDgField]="'name'">
@@ -49,8 +49,9 @@
 
   <clr-dg-row *ngFor="let item of vchs">
     <clr-dg-action-overflow class="{{item.name}}">
-      <button class="action-item action-item-delete" (click)="launchDeleteVchModal(item.id)">Delete</button>
-      <button class="action-item action-item-cert" (click)="downloadVchCert(item)">Download VCH certificate</button>
+      <button class="action-item action-item-cert" (click)="downloadVchCert(item)">{{vicI18n.translate(this.WS_VCH_CONSTANTS.DG.ACTIONS, 'DOWNLOAD_CERT')}}</button>
+      <button class="action-item action-item-reconfigure" (click)="navigateToObject(item.id, VIC_CONFIGURE_GENERAL_KEY)">{{vicI18n.translate(this.WS_VCH_CONSTANTS.DG.ACTIONS, 'RECONFIGURE')}}</button>
+      <button class="action-item action-item-delete" (click)="launchDeleteVchModal(item.id)">{{vicI18n.translate(this.WS_VCH_CONSTANTS.DG.ACTIONS, 'DELETE')}}</button>
     </clr-dg-action-overflow>
     <clr-dg-row-detail>
       <clr-dg-cell>


### PR DESCRIPTION
This change will introduce a new action on the Virtual Container Hosts view datagrid. This new action will allow users to go to the reconfigure page of the desired VCH on the list.

Fixes #494 

PR acceptance checklist:

[ x ] All unit tests pass
[ x ] All e2e tests pass
[ n/a ] Unit test(s) included*
[ n/a ] e2e test(s) included*
[ x ] Screenshot attached and UX approved*

![reconfigure-action-menu](https://user-images.githubusercontent.com/36636787/41412132-6a60ec34-6fb5-11e8-93c1-6b4d7d13ff5d.gif)

