### PR TITLE
Add downstream trigger to drone build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -100,6 +100,20 @@ pipeline:
     files:
       - 'h5c/vic/src/vic-webapp/coverage/lcov.info'
 
+  trigger-downstream:
+    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.1'
+    environment:
+      SHELL: /bin/bash
+      DOWNSTREAM_REPO: vmware/vic
+    secrets:
+      - drone_server
+      - drone_token
+    when:
+      repo: vmware/vic-ui
+      event: [push, tag]
+      branch: [master, 'releases/*']
+      status: success
+
   pass-rate:
     image: 'gcr.io/eminent-nation-87317/vic-integration-test:1.42'
     pull: true


### PR DESCRIPTION
At the completion of each vic-ui build following a push to master or a release branch, trigger a new build of vic. This will then trigger a new build of vic-product, producing an OVA with the latest UI version.
    
This strategy has some limitations:
 * The downstream-trigger currently restarts the most recent build on
   the target repository. However, this most recent build may not be
   on the expected branch. (This will need to be addressed in the
   downstream-trigger logic.)
 * All CI OVA builds are currently published to the same directory,
   making it difficult for UI automation to chose the correct OVA to
   test as the intent of the automation is to test the latest build
   from a specific branch. (This will need to be addressed by larger
   changes to the way Drone publishes artifacts to GCS. In the short
   term, it may be possible to work around this limitation in the UI
   automation by using the drone API to determine the latest OVA from
   the master branch.)

---

PR acceptance checklist:

- [ ] All unit tests pass
- [ ] All e2e tests pass
- [ ] Unit test(s) included*
- [ ] e2e test(s) included*
- [ ] Screenshot attached and UX approved (N/A)