### PR TITLE
Fix the endpoint to fetch the hosts of a VDS

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.component.ts
@@ -59,7 +59,7 @@ export class ComputeCapacityComponent implements OnInit {
     cpu: { maxUsage: null, minUsage: null, unreservedForPool: null },
     memory: { maxUsage: null, minUsage: null, unreservedForPool: null }
   };
-  public selectedObjectName: string;
+  public selectedObject: ComputeResource;
   public selectedResourceObjRef: string;
   public serversInfo: ServerInfo[];
   public selectedResourceIsCluster = false;
@@ -184,7 +184,7 @@ export class ComputeCapacityComponent implements OnInit {
         `${computeResource}/${payload.obj.realName}`;
     }
     this.selectedResourceObjRef = resourceObj;
-    this.selectedObjectName = payload.obj.realName;
+    this.selectedObject = payload.obj;
     this._selectedComputeResource = computeResource;
 
     // set active class on the treenodecomponent whose datacenter object reference is

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.html
@@ -112,7 +112,7 @@
 
     <vic-vch-creation-networks #networksStep
                                [datacenter]="computeCapacityStep.dcObj"
-                               [resourceObjName]="computeCapacityStep.selectedObjectName">
+                               [resourceObj]="computeCapacityStep.selectedObject">
     </vic-vch-creation-networks>
 
   </clr-wizard-page>

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.service.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.service.spec.ts
@@ -31,12 +31,15 @@ import { JASMINE_TIMEOUT } from '../testing/jasmine.constants';
 import { CreateVchWizardService } from './create-vch-wizard.service';
 import { Globals, GlobalsService } from '../shared';
 import {
+  ClusterHostsChilds,
   computeResourcesRealName,
   dcClustersAndStandAloneHosts,
   dcDSwitchPorGroupsList, dcMockData, dvsHostsEntries,
   folderDSwitchList, folderDSwitchPorGroupsList,
   netWorkingResources
 } from './mocks/create-vch-wizard-mocked-data';
+import {ComputeResource} from '../interfaces/compute.resource';
+import {COMPUTE_RESOURCE_NODE_TYPES} from '../shared/constants';
 
 describe('CreateVchWizardService', () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = JASMINE_TIMEOUT;
@@ -127,17 +130,33 @@ describe('CreateVchWizardService', () => {
       spyOn<any>(service, 'getDvsFromNetworkFolders').and.returnValue(Observable.of(folderDSwitchList));
       spyOn<any>(service, 'getDvsPortGroups').and.returnValue([...folderDSwitchPorGroupsList, ...dcDSwitchPorGroupsList]);
       spyOn<any>(service, 'getDvsHostsEntries').and.returnValue(dvsHostsEntries);
+      spyOn<any>(service, 'getHostsFromComputeResource').and.returnValue(ClusterHostsChilds);
 
-      service.getDistributedPortGroups(null, '10.192.109.234')
-        .subscribe(data => {
-            expect(data.length).toBe(8);
-          });
+      const selectedHostResource: ComputeResource = {
+        text: '10.192.109.234',
+        nodeTypeId: COMPUTE_RESOURCE_NODE_TYPES.host.dc_stand_alone,
+        objRef: 'urn:vmomi:ClusterComputeResource:host-276:d7c361cc-0a46-441e-8e21-ac22debf7003',
+        aliases: ['alias-id1'],
+        isEmpty: true
+      };
 
-      service.getDistributedPortGroups(null, 'New Cluster')
+      const selectedClusterResource: ComputeResource = {
+        text: 'New Cluster',
+        nodeTypeId: COMPUTE_RESOURCE_NODE_TYPES.cluster.dc_cluster,
+        objRef: 'urn:vmomi:ClusterComputeResource:domain-c270:d7c361cc-0a46-441e-8e21-ac22debf7003',
+        aliases: ['alias-id1'],
+        isEmpty: true
+      };
+
+      service.getDistributedPortGroups(null, selectedHostResource)
         .subscribe(data => {
           expect(data.length).toBe(3);
-          });
+        });
 
+      service.getDistributedPortGroups(null, selectedClusterResource)
+        .subscribe(data => {
+          expect(data.length).toBe(3);
+        });
     });
 
     it('should return a list of Compute Resources with a property called realName', async() => {

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/mocks/create-vch-wizard-mocked-data.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/mocks/create-vch-wizard-mocked-data.ts
@@ -157,86 +157,48 @@ export const dcDSwitchPorGroupsList = [
 ];
 
 export const dvsHostsEntries = [
-  Observable.of({
-    id: 'urn:vmomi:VmwareDistributedVirtualSwitch:dvs-29:d7c361cc-0a46-441e-8e21-ac22debf7003',
-    'dvs:dvsHostsData': {
-      dvsHosts: [
-        {
-          hostName: '10.192.109.234',
-          clusterName: null,
-          connectionState: 'connected',
-          connectionStateLabel: 'Connected',
-          hostIconId: 'vsphere-icon-host-warning',
-          vdsState: 'Up',
-          vdsStateIcon: 'statusGreen',
-          hostRef: {value: 'host-94', type: 'HostSystem', serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003'},
-          compatibilityErrors: []
-        }
-      ]}
-  }),
-  Observable.of({
-    id: 'urn:vmomi:VmwareDistributedVirtualSwitch:dvs-25:d7c361cc-0a46-441e-8e21-ac22debf7003',
-    'dvs:dvsHostsData': {
-      dvsHosts: [
-        {
-          hostName: '10.161.251.202',
-          clusterName: 'New Cluster',
-          connectionState: 'connected',
-          connectionStateLabel: 'Connected',
-          hostIconId: 'vsphere-icon-host-warning',
-          vdsState: 'Up',
-          vdsStateIcon: 'statusGreen',
-          hostRef: {value: 'host-20', type: 'HostSystem', serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003'},
-          compatibilityErrors: []
-        },
-        {
-          hostName: '10.162.17.176',
-          clusterName: 'New Cluster',
-          connectionState: 'connected',
-          connectionStateLabel: 'Connected',
-          hostIconId: 'vsphere-icon-host-warning',
-          vdsState: 'Up',
-          vdsStateIcon: 'statusGreen',
-          hostRef: {value: 'host-9', type: 'HostSystem', serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003'},
-          compatibilityErrors: []
-        }
-      ]}
-  }),
-  Observable.of({
-    id: 'urn:vmomi:VmwareDistributedVirtualSwitch:dvs-82:d7c361cc-0a46-441e-8e21-ac22debf7003',
-    'dvs:dvsHostsData': {
-      dvsHosts: [
-        {
-          hostName: '10.192.109.234',
-          clusterName: null,
-          connectionState: 'connected',
-          connectionStateLabel: 'Connected',
-          hostIconId: 'vsphere-icon-host-warning',
-          vdsState: 'Up',
-          vdsStateIcon: 'statusGreen',
-          hostRef: {value: 'host-94', type: 'HostSystem', serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003'},
-          compatibilityErrors: []
-        }
-      ]}
-  }),
-  Observable.of({
-    id: 'urn:vmomi:VmwareDistributedVirtualSwitch:dvs-86:d7c361cc-0a46-441e-8e21-ac22debf7003',
-    'dvs:dvsHostsData': {
-      dvsHosts: [
-        {
-          hostName: '10.192.109.234',
-          clusterName: null,
-          connectionState: 'connected',
-          connectionStateLabel: 'Connected',
-          hostIconId: 'vsphere-icon-host-warning',
-          vdsState: 'Up',
-          vdsStateIcon: 'statusGreen',
-          hostRef: {value: 'host-94', type: 'HostSystem', serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003'},
-          compatibilityErrors: []
-        }
-      ]}
-  })
+  Observable.of([
+    {
+      serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
+      type: 'HostSystem',
+      value: 'host-276'
+    }
+  ]),
+  Observable.of([
+    {
+      serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
+      type: 'HostSystem',
+      value: 'host-277'
+    },
+    {
+      serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
+      type: 'HostSystem',
+      value: 'host-278'
+    }
+  ]),
+  Observable.of([
+    {
+      serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
+      type: 'HostSystem',
+      value: 'host-279'
+    }
+  ]),
+  Observable.of([
+    {
+      serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
+      type: 'HostSystem',
+      value: 'host-280'
+    }
+  ])
 ];
+
+export const ClusterHostsChilds = Observable.of([
+    {
+      serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
+      type: 'HostSystem',
+      value: 'host-276'
+    }
+]);
 
 export const dcMockData = [
   {

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.ts
@@ -37,7 +37,7 @@ export class NetworksComponent implements OnInit {
   public portgroupsLoading = true;
   public portgroups: any[] = [];
 
-  @Input() resourceObjName: any;
+  @Input() resourceObj: ComputeResource;
   @Input() datacenter: ComputeResource;
 
   constructor(
@@ -138,9 +138,9 @@ export class NetworksComponent implements OnInit {
     });
   }
 
-  loadPortgroups(computeResourceObjName: string) {
+  loadPortgroups(computeResourceObj: ComputeResource) {
     this.portgroupsLoading = true;
-    this.createWzService.getDistributedPortGroups(this.datacenter, computeResourceObjName)
+    this.createWzService.getDistributedPortGroups(this.datacenter, computeResourceObj)
       .subscribe(v => {
         this.portgroups = v;
         this.form.get('bridgeNetwork').setValue('');
@@ -150,9 +150,10 @@ export class NetworksComponent implements OnInit {
         this.portgroupsLoading = false;
       }, err => console.error(err));
   }
+
   onPageLoad() {
     if (this.portgroups.length) {
-      this.loadPortgroups(this.resourceObjName);
+      this.loadPortgroups(this.resourceObj);
       return;
     }
 
@@ -278,7 +279,7 @@ export class NetworksComponent implements OnInit {
       });
 
       // load portgroups
-      this.loadPortgroups(this.resourceObjName);
+      this.loadPortgroups(this.resourceObj);
   }
 
   /**

--- a/h5c/vic/src/vic-webapp/src/app/interfaces/api-responses.ts
+++ b/h5c/vic/src/vic-webapp/src/app/interfaces/api-responses.ts
@@ -1,0 +1,5 @@
+export interface HostTypeInfo {
+  serverGuid: string;
+  type: string;
+  value: string;
+}

--- a/h5c/vic/src/vic-webapp/src/app/shared/constants/nodetype.ts
+++ b/h5c/vic/src/vic-webapp/src/app/shared/constants/nodetype.ts
@@ -16,3 +16,29 @@
 
 export const DC_CLUSTER = 'DcCluster';
 export const DC_STANDALONE_HOST = 'DcStandaloneHost';
+
+export const COMPUTE_RESOURCE_NODE_TYPES = {
+  dc: {
+    dc: 'Datacenter'
+  },
+  folder: {
+    dc_folder: 'DcCompResFolder',
+    comp_res_folder: 'CompResFolderCompResFolder'
+  },
+  host: {
+    dc_stand_alone: 'DcStandaloneHost',
+    cluster_host: 'ClusterHostSystem'
+  },
+  cluster: {
+    dc_cluster: 'DcCluster',
+    folder_cluster: 'CompResFolderCluster'
+  },
+  resource_pool: {
+    resource_pool: 'ResourcePool',
+    host_resource_pool: 'StandaloneHostResPool',
+    cluster_resource_pool: 'ClusterResPool',
+    resource_pool_resource_pool: 'ResPoolResPool',
+    vic_vch_resource_pool: 'VicVchResourcePool'
+  }
+};
+

--- a/h5c/vic/src/vic-webapp/src/app/shared/utils/object-reference.ts
+++ b/h5c/vic/src/vic-webapp/src/app/shared/utils/object-reference.ts
@@ -17,6 +17,7 @@ import { VirtualContainerHost } from './../../vch-view/vch.model';
 
 import { ComputeResource } from './../../interfaces/compute.resource';
 import { ServerInfo } from '../vSphereClientSdkTypes';
+import {COMPUTE_RESOURCE_NODE_TYPES} from '../constants';
 
 export function getServerServiceGuidFromObj (obj: ComputeResource): string {
   return obj.objRef.split(':')[4];
@@ -54,4 +55,15 @@ export function getServerInfoByVchObjRef (serversInfo: ServerInfo[], vch: Virtua
     return item.serviceGuid === vch.id.substr(idx + 1);
   });
   return filtered[0] || null;
+}
+
+export function isDesiredType(type: string, types: string[]): boolean {
+  return types.indexOf(type) !== -1;
+}
+
+export function resourceIsCluster(type: string): boolean {
+  return isDesiredType(type, [
+    COMPUTE_RESOURCE_NODE_TYPES.cluster.dc_cluster,
+    COMPUTE_RESOURCE_NODE_TYPES.cluster.folder_cluster
+  ]);
 }

--- a/h5c/vic/src/vic-webapp/src/environments/global-properties.ts
+++ b/h5c/vic/src/vic-webapp/src/environments/global-properties.ts
@@ -1,0 +1,11 @@
+export const globalProperties = {
+  // vic service
+  vicService: {
+    paths: {
+      base: '/ui/vic/rest/data/',
+      get properties () {return `${this.base}properties/`},
+      get list () {return `${this.base}list/`},
+      get propertiesByRelation () {return `${this.base}propertiesByRelation/`},
+    }
+  }
+};


### PR DESCRIPTION
This change will fix the endpoint to fetch the hosts of a VDS during VCH Creation Wizard in the Networ step. The new endpoint will be /ui/vic/rest/data/properties and it will be handled by our own vic java service layer.

Fixes #504 

PR acceptance checklist:

[ x ] All unit tests pass
[ x ] All e2e tests pass
[ x ] Unit test(s) included*
[ n/a ] e2e test(s) included*
[ n/a ] Screenshot attached and UX approved*

 *if applicable, add n/a if not
