### PR TITLE
Fix bug installing VIC plugin

### DIFF
--- a/scripts/VCSA/install.sh
+++ b/scripts/VCSA/install.sh
@@ -261,7 +261,7 @@ verify_plugin_url() {
         exit 1
     fi
 
-    local RESPONSE_STATUS=$(echo $CURL_RESPONSE | grep -i "HTTP" | grep "4[[:digit:]][[:digit:]]\|500")
+    local RESPONSE_STATUS=$(curl -sko /dev/null -I -w "%{http_code}" ${VIC_UI_HOST_URL}files/$PLUGIN_BASENAME 2>&1)
     if [[ $(echo $RESPONSE_STATUS | grep -oi "404") ]] ; then
         echo "-------------------------------------------------------------"
         echo "Error! Plugin bundle was not found. Please make sure \"$PLUGIN_BASENAME\" is available at \"$VIC_UI_HOST_URL\", and retry installing the plugin"


### PR DESCRIPTION
This changes fix the bug installing vic plugin and coincidentally the Content Length has `404` pattern in it.
The case that trigger this failure was: 
`'Date: Wed, 20 Jun 2018 16:25:24 GMT08:08 GMT-- 0 HTTP/1.1 200 OK Time Time Time Current Dload Upload Total Spent Left Speed
++ echo % Total % Received % Xferd Average Speed Time Time Time Current Dload Upload Total Spent Left Speed $'\r' 0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- $'0\r' 0 6330k 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0 HTTP/1.1 200 $'OK\r' Accept-Ranges: $'bytes\r' Content-Length: $'6482404\r' Content-Type: $'application/zip\r' Last-Modified: Tue, 19 Jun 2018 22:08:08 $'GMT\r' Date: Wed, 20 Jun 2018 16:25:24 $'GMT\r' $'\r'`

in which `Content-Length: $'6482404\r` has **404** pattern 

and validate incorrecltly the condition:

`local RESPONSE_STATUS=$(echo $CURL_RESPONSE | grep -i "HTTP" | grep "4[[:digit:]][[:digit:]]\|500")
   if [[ $(echo $RESPONSE_STATUS | grep -oi "404") ]] ; then
       echo "-------------------------------------------------------------"
       echo "Error! Plugin bundle was not found. Please make sure \"$PLUGIN_BASENAME\" is available at \"$VIC_UI_HOST_URL\", and retry installing the plugin"
       exit 1
   fi`


<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic-ui/blob/master/.github/CONTRIBUTING.md
-->

Fixes #528 

Without fix:

![fail_installation](https://user-images.githubusercontent.com/29590874/41677954-21e57804-74a0-11e8-87aa-e3fe6eab94a0.gif)


With fix:
![success_install](https://user-images.githubusercontent.com/29590874/41677962-27ce3f44-74a0-11e8-831b-f15db0c05f92.gif)


