### PR TITLE
Cherry-pick: Fixed insecure registry with missing port not shown on summary (#467)

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/registry-access/registry-access.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/registry-access/registry-access.component.spec.ts
@@ -14,10 +14,11 @@
  limitations under the License.
 */
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {ReactiveFormsModule} from '@angular/forms';
+import {ReactiveFormsModule, FormGroup} from '@angular/forms';
 import {ClarityModule} from '@clr/angular';
 import {HttpModule} from '@angular/http';
 import {RegistryAccessComponent} from './registry-access.component';
+import { FormBuilder, FormArray, FormControl} from '@angular/forms';
 
 describe('RegistryAccessComponent', () => {
 
@@ -31,8 +32,9 @@ describe('RegistryAccessComponent', () => {
         HttpModule,
         ClarityModule
       ],
-      declarations: [
-        RegistryAccessComponent
+      declarations: [RegistryAccessComponent],
+      providers: [
+        FormBuilder
       ]
     });
   });
@@ -57,6 +59,41 @@ describe('RegistryAccessComponent', () => {
 
     component.form.get('useWhitelistRegistry').setValue(true);
     expect(component.form.get('whitelistRegistries').enabled).toBeTruthy();
+  });
+
+  it('should add insecure registry entries without port', () => {
+    let insecureRegistry1, insecureRegistry2: FormGroup;
+    const control = component.form.get('insecureRegistries') as FormArray;
+    component.removeFormArrayEntry('insecureRegistries', 0);
+    // Adding one registry with port
+    insecureRegistry1 = component.createNewFormArrayEntry('insecureRegistries');
+    insecureRegistry1.controls['insecureRegistryIp'].setValue('1.2.3.4');
+    insecureRegistry1.controls['insecureRegistryPort'].setValue('22');
+    control.push(insecureRegistry1);
+    // Adding one registry without port
+    insecureRegistry2 = component.createNewFormArrayEntry('insecureRegistries');
+    insecureRegistry2.controls['insecureRegistryIp'].setValue('4.3.2.1');
+    control.push(insecureRegistry2);
+    component.onCommit().subscribe(
+      res => {
+        expect(res.registry.insecureRegistry.length).toBe(2);
+      }
+    )
+  });
+
+  it('should not add insecure registry entries without ip', () => {
+    let insecureRegistry1: FormGroup;
+    const control = component.form.get('insecureRegistries') as FormArray;
+    component.removeFormArrayEntry('insecureRegistries', 0);
+    // Adding one registry without ip
+    insecureRegistry1 = component.createNewFormArrayEntry('insecureRegistries');
+    insecureRegistry1.controls['insecureRegistryPort'].setValue('22');
+    control.push(insecureRegistry1);
+    component.onCommit().subscribe(
+      res => {
+        expect(res.registry.insecureRegistry.length).toBe(0);
+      }
+    )
   });
 
   it('should add and remove registry certificate entries', () => {

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/registry-access/registry-access.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/registry-access/registry-access.component.ts
@@ -129,8 +129,9 @@ export class RegistryAccessComponent {
     if (!useWhitelistRegistryValue) {
       results['whitelistRegistry'] = [];
       results['insecureRegistry'] = insecureRegistriesValue.filter(val => {
-        return val['insecureRegistryIp'] && val['insecureRegistryPort'];
-      }).map(val => `${val['insecureRegistryIp']}:${val['insecureRegistryPort']}`);
+        return val['insecureRegistryIp'];
+      }).map(val => (val['insecureRegistryPort'] === '' ? `${val['insecureRegistryIp']}` :
+       `${val['insecureRegistryIp']}:${val['insecureRegistryPort']}`));
     } else {
       const white = [];
       const insecure = [];


### PR DESCRIPTION
*   Fixed insecure registry with missing port not shown on the summary

*   Fix only show the colon after the ip if there is a port number

*   Add unit tests to validate insecure registries without port and without ip

*    Deleting console logs outputs

(cherry picked from commit e8e3267)