### PR TITLE
Update drone config to specify downstream branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -101,17 +101,33 @@ pipeline:
       - 'h5c/vic/src/vic-webapp/coverage/lcov.info'
 
   trigger-downstream:
-    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.1'
+    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.3'
     environment:
       SHELL: /bin/bash
       DOWNSTREAM_REPO: vmware/vic
+      DOWNSTREAM_BRANCH: ${DRONE_BRANCH}
     secrets:
       - drone_server
       - drone_token
     when:
       repo: vmware/vic-ui
-      event: [push, tag]
-      branch: [master, develop, 'releases/*']
+      event: [push]
+      branch: [master]
+      status: success
+
+  trigger-downstream-tag:
+    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.3'
+    environment:
+      SHELL: /bin/bash
+      DOWNSTREAM_REPO: vmware/vic
+      DOWNSTREAM_BRANCH: ${DRONE_BRANCH}
+    secrets:
+      - drone_server
+      - drone_token
+    when:
+      repo: vmware/vic-ui
+      event: [tag]
+      branch: [master, 'releases/*']
       status: success
 
   pass-rate:


### PR DESCRIPTION
The `master` branch of vic consumes the latest build from the `master` branch of vic-ui. Therefore it makes sense to trigger a build of `master` for each `push` to `master`.

The `release/*` branches of vic only consume `tag` builds of vic-ui. Therefore it makes sense to only trigger new builds of vic's release branches when performing a `tag` build of vic.

Eventually, we will be able to supply a specific build to be used by the downstream branch (see vmware/vic#6554). At that point, it will make sense to trigger downstream jobs as a result of `push` events to `develop` and `pull_request` events on all branches.

Related: vmware/vic#8057, vmware/vic#8058

---

PR acceptance checklist:

[n/a] All unit tests pass
[n/a] All e2e tests pass
[n/a] Unit test(s) included*
[n/a] e2e test(s) included*
[n/a] Screenshot attached and UX approved*

 *if applicable, add n/a if not