### PR TITLE
Use parameterized vcenter and exsi version on setup-testbed robot file instead of hardcoded ones

### DIFF
--- a/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
+++ b/tests/test-cases/Group18-VIC-UI/kickoff-tests.robot
@@ -98,35 +98,35 @@ Setup Test Matrix
     # skip matrix
     @{skip_test_config_matrix}=  Create List
     # There's currently a version clash between the Selenium standalone binary and HSUIA project
-    Append To List  ${skip_test_config_matrix}  65,5969303,7515524,Windows,Firefox,Firefox
+    Append To List  ${skip_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Windows,Firefox,Firefox
     # There's a H5C bug in IE11 that appears only when automatically tested
-    Append To List  ${skip_test_config_matrix}  65,5969303,7515524,Windows,IExplorer,IE11
+    Append To List  ${skip_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Windows,IExplorer,IE11
     Set Global Variable  ${SKIP_TEST_MATRIX}  ${skip_test_config_matrix}
 
     # installer test matrix
     @{installer_test_config_matrix}=  Create List
     &{installer_test_results_dict}=  Create Dictionary
-    Append To List  ${installer_test_config_matrix}  65,5969303,7515524,Ubuntu
-    Append To List  ${installer_test_config_matrix}  65,5969303,7515524,Mac
-    Append To List  ${installer_test_config_matrix}  65,5969303,7515524,Windows
+    Append To List  ${installer_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Ubuntu
+    Append To List  ${installer_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Mac
+    Append To List  ${installer_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Windows
     Set Global Variable  ${INSTALLER_TEST_MATRIX}        ${installer_test_config_matrix}
     Set Global Variable  ${INSTALLER_TEST_RESULTS_DICT}  ${installer_test_results_dict}
 
     # uninstaller test matrix
     @{uninstaller_test_config_matrix}=  Create List
     &{uninstaller_test_results_dict}=  Create Dictionary
-    Append To List  ${uninstaller_test_config_matrix}  65,5969303,7515524,Ubuntu
-    Append To List  ${uninstaller_test_config_matrix}  65,5969303,7515524,Mac
-    Append To List  ${uninstaller_test_config_matrix}  65,5969303,7515524,Windows
+    Append To List  ${uninstaller_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Ubuntu
+    Append To List  ${uninstaller_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Mac
+    Append To List  ${uninstaller_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Windows
     Set Global Variable  ${UNINSTALLER_TEST_MATRIX}        ${uninstaller_test_config_matrix}
     Set Global Variable  ${UNINSTALLER_TEST_RESULTS_DICT}  ${uninstaller_test_results_dict}
 
     # upgrader test matrix
     @{upgrader_test_config_matrix}=  Create List
     &{upgrader_test_results_dict}=  Create Dictionary
-    Append To List  ${upgrader_test_config_matrix}  65,5969303,7515524,Ubuntu
-    Append To List  ${upgrader_test_config_matrix}  65,5969303,7515524,Mac
-    Append To List  ${upgrader_test_config_matrix}  65,5969303,7515524,Windows
+    Append To List  ${upgrader_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Ubuntu
+    Append To List  ${upgrader_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Mac
+    Append To List  ${upgrader_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Windows
     Set Global Variable  ${UPGRADER_TEST_MATRIX}        ${upgrader_test_config_matrix}
     Set Global Variable  ${UPGRADER_TEST_RESULTS_DICT}  ${upgrader_test_results_dict}
 
@@ -135,11 +135,11 @@ Setup Test Matrix
     &{plugin_test_results_dict}=  Create Dictionary
     # vSphere H5C and Flex Client are not supported  on Linux
     # https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.upgrade.doc/GUID-F6D456D7-C559-439D-8F34-4FCF533B7B42.html
-    Append To List  ${plugin_test_config_matrix}  65,5969303,7515524,Mac,Chrome,Chrome
-    Append To List  ${plugin_test_config_matrix}  65,5969303,7515524,Mac,Firefox,Firefox
-    Append To List  ${plugin_test_config_matrix}  65,5969303,7515524,Windows,Chrome,Chrome
-    Append To List  ${plugin_test_config_matrix}  65,5969303,7515524,Windows,Firefox,Firefox
-    Append To List  ${plugin_test_config_matrix}  65,5969303,7515524,Windows,IExplorer,IE11
+    Append To List  ${plugin_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Mac,Chrome,Chrome
+    Append To List  ${plugin_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Mac,Firefox,Firefox
+    Append To List  ${plugin_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Windows,Chrome,Chrome
+    Append To List  ${plugin_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Windows,Firefox,Firefox
+    Append To List  ${plugin_test_config_matrix}  %{VC_VER_NO},%{ESX_BUILD_NO},%{VC_BUILD_NO},Windows,IExplorer,IE11
     Set Global Variable  ${PLUGIN_TEST_MATRIX}        ${plugin_test_config_matrix}
     Set Global Variable  ${PLUGIN_TEST_RESULTS_DICT}  ${plugin_test_results_dict}
 

--- a/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -96,11 +96,11 @@ Deploy VICUI Testbed
     Run Keyword If  ${ti_exists}  Remove File  testbed-information-%{BUILD_NUMBER}
 
     &{testbed_config}=  Create Dictionary
-
+    
     Set To Dictionary  ${testbed_config}  esx_num  ${ESXIS_NUM}
-    Set To Dictionary  ${testbed_config}  esx_build  5969303
-    Set To Dictionary  ${testbed_config}  vc_build  7515524
-
+    Set To Dictionary  ${testbed_config}  esx_build  %{ESX_BUILD_NO} 
+    Set To Dictionary  ${testbed_config}  vc_build  %{VC_BUILD_NO} 
+    
     ${start_time}=  Get Time  epoch
     ${esxis}  ${vc}=  Prepare VIC UI Testbed  ${testbed_config}
     ${vc_fqdn}=  Get From Dictionary  ${vc}  ip
@@ -113,7 +113,7 @@ Deploy VICUI Testbed
     Set Global Variable  ${VCIP}  ${vc_fqdn}
 
     ${testbed-information-content}=  Catenate  SEPARATOR=\n
-    ...  TEST_VSPHERE_VER=65
+    ...  TEST_VSPHERE_VER=%{VC_VER_NO}
     ...  TEST_VC_IP=${vc_fqdn}
     ...  TEST_URL_ARRAY=${vc_fqdn}
     ...  TEST_USERNAME=Administrator@vsphere.local

--- a/tests/test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/test-cases/Group18-VIC-UI/vicui-common.robot
@@ -329,7 +329,7 @@ Prepare VIC Engine Binaries
     Run  cp -rf ui-nightly-run-bin/ui/* scripts/
 
 Open SSH Connection
-  [Arguments]  ${host}  ${user}  ${pass}  ${port}=22  ${retry}=2 minutes  ${retry_interval}=5 seconds
+  [Arguments]  ${host}  ${user}  ${pass}  ${port}=22  ${retry}=4 minutes  ${retry_interval}=12 seconds
   Open Connection  ${host}  port=${port}
   Wait until keyword succeeds  ${retry}  ${retry_interval}  Login  ${user}  ${pass}
 
@@ -452,7 +452,7 @@ Configure Vcsa
 
     # create a distributed switch
     Log To Console  Create a distributed switch
-    ${out}=  Run  govc dvs.create -dc=Datacenter test-ds
+    ${out}=  Run  govc dvs.create -dc=Datacenter -product-version 6.5.0 test-ds
     Should Contain  ${out}  OK
 
     # make four port groups

--- a/tests/test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/test-cases/Group18-VIC-UI/vicui-common.robot
@@ -452,7 +452,7 @@ Configure Vcsa
 
     # create a distributed switch
     Log To Console  Create a distributed switch
-    ${out}=  Run  govc dvs.create -dc=Datacenter -product-version 6.5.0 test-ds
+    ${out}=  Run  govc dvs.create -dc=Datacenter -product-version 5.5.0 test-ds
     Should Contain  ${out}  OK
 
     # make four port groups


### PR DESCRIPTION
**Summary of changes:**

- Increase the poll time and retry time to get the response of the ssh service of the vcenter to prevent ssh connection timeouts.

- Stablish the minimum compatible esxi host version at the moment of the dvs creation (if we leave it blank it by default takes the exsi version as minimum dvs product compatible version, if we are deploying a 6.7 version, then 6.7 would be the minimum version and there is a big backward compatibility issue with already 6.5.0, 6.0.0 or 5.5.0 deployed versions, and those < 6.7.0 version can't be used, causing a failure on the e2e script, this happened when we did sanity checks against 6.7 version) .

- Read Jenkins jobs local variables for the vcenter build version and exsi version instead of the hardcoded ones.


Fixes #550 


PR acceptance checklist:

[ ] All unit tests pass
[ ] All e2e tests pass
[ ] Unit test(s) included*
[ ] e2e test(s) included*
[ ] Screenshot attached and UX approved*

 *if applicable, add n/a if not
