### PR TITLE
Resource tree selector refactor

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/app.module.ts
+++ b/h5c/vic/src/vic-webapp/src/app/app.module.ts
@@ -35,6 +35,7 @@ import { AppRoutingModule, routedComponents } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { DisableCookieXSRFStrategy } from './shared/utils/disable-cookie-xsrf-strategy';
 import { HttpInterceptorService } from './services/http-interceptor.service';
+import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
   imports: [
@@ -42,6 +43,7 @@ import { HttpInterceptorService } from './services/http-interceptor.service';
     BrowserAnimationsModule,
     AppRoutingModule,
     HttpModule,
+    HttpClientModule,
     ClarityModule.forRoot()
   ],
   declarations: [

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.component.spec.ts
@@ -22,8 +22,8 @@ import {CreateVchWizardService} from '../create-vch-wizard.service';
 import {HttpModule} from '@angular/http';
 import {Observable} from 'rxjs/Observable';
 import {ReactiveFormsModule} from '@angular/forms';
-import {TestScheduler} from 'rxjs/Rx';
 import {AppAlertService, GlobalsService, I18nService} from '../../shared';
+import {mockedDcClustersAndStandAloneHostsList} from '../mocks/create-vch-wizard-mocked-data';
 
 describe('ComputeCapacityComponent', () => {
 
@@ -34,7 +34,7 @@ describe('ComputeCapacityComponent', () => {
   const MaxLimit = 4096;
 
   function setDefaultRequiredValues() {
-    component.loadResources(component.clusters[0].text);
+    component.resources = mockedDcClustersAndStandAloneHostsList;
     component.selectComputeResource({datacenterObj: component.datacenter, obj: component.resources[0]});
   }
 
@@ -56,7 +56,7 @@ describe('ComputeCapacityComponent', () => {
                 text: 'datacenter'
               }]);
             },
-            getClustersList(serviceGuid: string) {
+            getDcClustersAndStandAloneHosts(serviceGuid: string) {
               return Observable.of([{
                 text: 'cluster'
               }]);
@@ -130,9 +130,7 @@ describe('ComputeCapacityComponent', () => {
     service = fixture.debugElement.injector.get(CreateVchWizardService);
 
     spyOn(service, 'getDatacenter').and.callThrough();
-    spyOn(service, 'getClustersList').and.callThrough();
     spyOn(service, 'getResourceAllocationsInfo').and.callThrough();
-    spyOn(service, 'getHostsAndResourcePools').and.callThrough();
   });
 
   it('should be created', () => {
@@ -224,14 +222,9 @@ describe('ComputeCapacityComponent', () => {
     });
   });
 
-  it('should extract the datacenter moid from the object reference string', () => {
-    const dc = component.getDataCenterId('urn:vmomi:Datacenter:dc-test:00000000-0000-0000-0000-000000000000');
-    expect(dc).toEqual('dc-test');
-  });
-
   it('should validate advanced fields defaults values', () => {
     component.toggleAdvancedMode();
-    component.selectComputeResource({datacenterObj: component.datacenter, obj: {text: ''}});
+    component.selectComputeResource({datacenterObj: component.datacenter, obj: mockedDcClustersAndStandAloneHostsList[0]});
     component.onCommit();
     expect(component.form.valid).toBe(true);
 

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.component.spec.ts
@@ -15,13 +15,22 @@
 */
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ClarityModule} from '@clr/angular';
-import { ComputeResourceTreenodeComponent } from './compute-resource-treenode.component';
+import {ComputeResourceTreenodeComponent} from './compute-resource-treenode.component';
 import {CreateVchWizardService} from '../create-vch-wizard.service';
 import {HttpModule} from '@angular/http';
 import {Observable} from 'rxjs/Observable';
 import {ReactiveFormsModule} from '@angular/forms';
 import {Globals, GlobalsService} from '../../shared';
-import {ServerInfo} from '../../shared/vSphereClientSdkTypes';
+import {HttpClientModule} from '@angular/common/http';
+import {VicVmViewService} from '../../services/vm-view.service';
+import {
+  mockedClusterHostsList1,
+  mockedClusterHostsList2,
+  datacenter,
+  datacenter1,
+  mockedDcClustersAndStandAloneHostsList,
+  vicResourcePoolList
+} from '../mocks/create-vch-wizard-mocked-data';
 
 describe('ComputeResourceTreenodeComponent', () => {
 
@@ -29,104 +38,19 @@ describe('ComputeResourceTreenodeComponent', () => {
   let fixture: ComponentFixture<ComputeResourceTreenodeComponent>;
   let service: CreateVchWizardService;
 
-  const datacenter = {
-    text: 'Datacenter',
-    spriteCssClass: 'vsphere-icon-datacenter',
-    hasChildren: true,
-    objRef: 'urn:vmomi:Datacenter:datacenter-2:d7c361cc-0a46-441e-8e21-ac22debf7003',
-    nodeTypeId: 'Datacenter',
-    isEmpty: null,
-    aliases: [
-      'urn:vmomi:Folder:group-h4:d7c361cc-0a46-441e-8e21-ac22debf7003',
-      'urn:vmomi:Folder:group-v3:d7c361cc-0a46-441e-8e21-ac22debf7003',
-      'urn:vmomi:Folder:group-s5:d7c361cc-0a46-441e-8e21-ac22debf7003',
-      'urn:vmomi:Folder:group-n6:d7c361cc-0a46-441e-8e21-ac22debf7003'
-    ]
-  };
-  const datacenter1 = {
-    text: 'Datacenter 1',
-    spriteCssClass: 'vsphere-icon-datacenter',
-    hasChildren: true,
-    objRef: 'urn:vmomi:Datacenter:datacenter-52:d7c361cc-0a46-441e-8e21-ac22debf7003',
-    nodeTypeId: 'Datacenter',
-    isEmpty: null,
-    aliases: [
-      'urn:vmomi:Folder:group-h54:d7c361cc-0a46-441e-8e21-ac22debf7003',
-      'urn:vmomi:Folder:group-v53:d7c361cc-0a46-441e-8e21-ac22debf7003',
-      'urn:vmomi:Folder:group-s55:d7c361cc-0a46-441e-8e21-ac22debf7003',
-      'urn:vmomi:Folder:group-n56:d7c361cc-0a46-441e-8e21-ac22debf7003'
-    ]
-  };
-  const serverInfoServiceGui = ' d7c361cc-0a46-441e-8e21-ac22debf7003';
-  const mockedClustersList = [
-    {
-      text: 'New Cluster',
-      spriteCssClass: 'vsphere-icon-cluster',
-      hasChildren: true,
-      objRef: 'urn:vmomi:ClusterComputeResource:domain-c23:d7c361cc-0a46-441e-8e21-ac22debf7003',
-      nodeTypeId: 'DcCluster',
-      aliases: ['urn:vmomi:ResourcePool:resgroup-24:d7c361cc-0a46-441e-8e21-ac22debf7003'],
-      datacenterObjRef: 'urn:vmomi:Datacenter:datacenter-2:d7c361cc-0a46-441e-8e21-ac22debf7003'
-    },
-    {
-      text: '10.192.109.234',
-      spriteCssClass: 'vsphere-icon-host-warning',
-      hasChildren: true,
-      objRef: 'urn:vmomi:HostSystem:host-94:d7c361cc-0a46-441e-8e21-ac22debf7003',
-      nodeTypeId: 'DcStandaloneHost',
-      aliases: ['urn:vmomi:ResourcePool:resgroup-93:d7c361cc-0a46-441e-8e21-ac22debf7003'],
-      datacenterObjRef: 'urn:vmomi:Datacenter:datacenter-2:d7c361cc-0a46-441e-8e21-ac22debf7003'
-    },
-    {
-      text: 'New Cluster 1',
-      spriteCssClass: 'vsphere-icon-cluster',
-      hasChildren: true,
-      objRef: 'urn:vmomi:ClusterComputeResource:domain-c98:d7c361cc-0a46-441e-8e21-ac22debf7003',
-      nodeTypeId: 'DcCluster',
-      aliases: ['urn:vmomi:ResourcePool:resgroup-99:d7c361cc-0a46-441e-8e21-ac22debf7003'],
-      datacenterObjRef: 'urn:vmomi:Datacenter:datacenter-52:d7c361cc-0a46-441e-8e21-ac22debf7003'
-    }
-  ];
-  const cluster1HostSystems = [
-    {
-      text: '10.161.251.202',
-      spriteCssClass: 'vsphere-icon-host-warning',
-      hasChildren: false,
-      objRef: 'urn:vmomi:HostSystem:host-20:d7c361cc-0a46-441e-8e21-ac22debf7003',
-      nodeTypeId: 'ClusterHostSystem',
-      aliases: null
-    },
-    {
-      text: '10.162.17.176',
-      spriteCssClass: 'vsphere-icon-host-warning',
-      hasChildren: false,
-      objRef: 'urn:vmomi:HostSystem:host-9:d7c361cc-0a46-441e-8e21-ac22debf7003',
-      nodeTypeId: 'ClusterHostSystem',
-      aliases: null
-    }
-  ];
-  const cluster2HostSystems = [
-    {
-      text: '10.192.115.9',
-      spriteCssClass: 'vsphere-icon-host-warning',
-      hasChildren: false,
-      objRef: 'urn:vmomi:HostSystem:host-101:d7c361cc-0a46-441e-8e21-ac22debf7003',
-      nodeTypeId: 'ClusterHostSystem',
-      aliases: null
-    }
-  ];
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
         ReactiveFormsModule,
         HttpModule,
+        HttpClientModule,
         ClarityModule
       ],
       providers: [
         CreateVchWizardService,
         Globals,
         GlobalsService,
+        VicVmViewService
       ],
       declarations: [
         ComputeResourceTreenodeComponent
@@ -142,28 +66,29 @@ describe('ComputeResourceTreenodeComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should retrieve hosts and clusters filtered by datacenter1', () => {
+  it('should retrieve a ComputeResource list filtered by type', () => {
     component.datacenter = datacenter1;
-    spyOn(service, 'getClustersList').and.returnValue(Observable.of(mockedClustersList));
-    spyOn(service, 'getAllClusterHostSystems').and.returnValue(Observable.of(cluster2HostSystems));
-    component.loadClusters(<ServerInfo>{serviceGuid: serverInfoServiceGui});
+    spyOn(service, 'getVicResourcePoolList').and.returnValue(Observable.of(vicResourcePoolList));
+    spyOn(service, 'getDcClustersAndStandAloneHosts').and.returnValue(Observable.of(mockedDcClustersAndStandAloneHostsList));
+    spyOn(service, 'getHostsAndResourcePoolsFromClusters').and.returnValue(Observable.of(mockedClusterHostsList2));
+    component.loadClustersAndStandAloneHosts();
 
-    expect(component.clusters.length).toBe(1);
-    expect(component.clusters[0].objRef).toBe(mockedClustersList[2].objRef);
-    expect(component.standaloneHosts.length).toBe(0);
-
+    expect(component.clusters.length).toBe(2);
+    expect(component.clusters[0].objRef).toBe(mockedDcClustersAndStandAloneHostsList[0].objRef);
+    expect(component.standaloneHosts.length).toBe(1);
   });
 
-  it('should retrieve hosts and clusters filtered by datacenter2', () => {
+  it('should retrieve a list of hosts belonging to a particular Cluster', () => {
     component.datacenter = datacenter;
-    spyOn(service, 'getClustersList').and.returnValue(Observable.of(mockedClustersList));
-    spyOn(service, 'getAllClusterHostSystems').and.returnValue(Observable.of(cluster1HostSystems));
-    component.loadClusters(<ServerInfo>{serviceGuid: serverInfoServiceGui});
+    spyOn(service, 'getVicResourcePoolList').and.returnValue(Observable.of(vicResourcePoolList));
+    spyOn(service, 'getDcClustersAndStandAloneHosts').and.returnValue(Observable.of(mockedDcClustersAndStandAloneHostsList));
+    spyOn(service, 'getHostsAndResourcePoolsFromClusters').and.returnValue(Observable.of(mockedClusterHostsList1));
+    component.loadClustersAndStandAloneHosts();
 
-    expect(component.clusters.length).toBe(1);
-    expect(component.clusters[0].objRef).toBe(mockedClustersList[0].objRef);
-    expect(component.standaloneHosts.length).toBe(1);
-
+    expect(component.clusterHostSystemsMap[mockedDcClustersAndStandAloneHostsList[0].objRef].length)
+      .toBe(mockedClusterHostsList1.length);
+    expect(component.clusterHostSystemsMap[mockedDcClustersAndStandAloneHostsList[0].objRef][0].objRef)
+      .toBe(mockedClusterHostsList1[0].objRef);
   });
 
 });

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.template.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.template.html
@@ -1,32 +1,49 @@
 <!-- Copyright 2017-2018 VMware, Inc. All Rights Reserved. -->
+
+<!-- tree template -->
+<ng-template #recursiveList let-items>
+  <ng-template [clrIfExpanded]="true"
+               *ngIf="items && items.length > 0">
+    <clr-tree-node *ngFor="let item of items"
+                   class="form-control"
+                   [ngSwitch]="item.type">
+      <button #btnEl
+              class="clr-treenode-link cc-resource"
+              (click)="selectResource($event, item)">
+        <clr-icon shape="host" *ngSwitchCase="'HostSystem'"></clr-icon>
+        <clr-icon shape="resource-pool" *ngSwitchCase="'ResourcePool'"></clr-icon>
+        {{ item.text }}
+      </button>
+      <!-- childs -->
+      <ng-template [clrIfExpanded]="true">
+        <ng-container *ngTemplateOutlet="recursiveList; context:{ $implicit: item['childs'] }"></ng-container>
+      </ng-template>
+    </clr-tree-node>
+  </ng-template>
+</ng-template>
+
+
 <!-- cluster and clusterhostsystems -->
-  <ng-container *ngFor="let cluster of clusters">
-      <clr-tree-node *ngIf="!cluster.isEmpty" [clrLoading]="loading">
-        <button #btnEl
-                class="clr-treenode-link cc-resource"
-                (click)="selectResource($event, cluster)">
-          <clr-icon shape="cluster"></clr-icon>
-          {{ cluster['text'] }}
-        </button>
+<ng-container *ngFor="let cluster of clusters">
+    <clr-tree-node *ngIf="!cluster.isEmpty" [clrLoading]="loading">
+      <button #btnEl
+              class="clr-treenode-link cc-resource"
+              (click)="selectResource($event, cluster)">
+        <clr-icon shape="cluster"></clr-icon>
+        {{ cluster['text'] }}
+      </button>
 
-        <ng-template [clrIfExpanded]="false">
-          <ng-container>
-            <clr-tree-node *ngFor="let clHost of clusterHostSystemsMap[cluster.objRef]">
-              <button #btnEl class="clr-treenode-link cc-resource">
-                <clr-icon shape="host"></clr-icon>
-                {{ clHost['text'] }}
-              </button>
-            </clr-tree-node>
+      <ng-template [clrIfExpanded]="false">
+        <ng-container>
+          <ng-container *ngTemplateOutlet="recursiveList; context:{ $implicit: clusterHostSystemsMap[cluster.objRef] }"></ng-container>
           </ng-container>
-        </ng-template>
-      </clr-tree-node>
-  </ng-container>
+      </ng-template>
+    </clr-tree-node>
+</ng-container>
 
-  <!-- standalone hosts -->
-  <clr-tree-node *ngFor="let host of standaloneHosts">
-    <button #btnEl class="clr-treenode-link cc-resource"
-            (click)="selectResource($event, host)">
-      <clr-icon shape="host"></clr-icon>
-      {{ host['text'] }}
-    </button>
-  </clr-tree-node>
+<!-- standalone hosts -->
+<ng-container *ngTemplateOutlet="recursiveList; context:{ $implicit: standaloneHosts }"></ng-container>
+
+
+
+

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.html
@@ -89,7 +89,7 @@
     <ng-template clrPageNavTitle>Storage Capacity</ng-template>
 
     <vic-vch-creation-storage-capacity #storageCapacityStep
-                                       [resourceObjRef]="computeCapacityStep.selectedResourceObjRef">
+                                       [resourceObjRef]="computeCapacityStep.selectedObject">
     </vic-vch-creation-storage-capacity>
 
   </clr-wizard-page>

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.ts
@@ -241,7 +241,7 @@ export class CreateVchWizardComponent implements OnInit {
           }
         },
         'resource': {
-          'name': payload.computeCapacity.computeResource
+          'id': payload.computeCapacity.computeResource
         }
       },
       'storage': {

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.module.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.module.ts
@@ -30,6 +30,7 @@ import { StorageCapacityComponent } from './storage-capacity/storage-capacity.co
 import { SummaryComponent } from './summary/summary.component';
 import { VchCreationWizardGeneralComponent } from './general/general.component';
 import { RegistryAccessComponent } from './registry-access/registry-access.component';
+import { VicVmViewService } from '../services/vm-view.service';
 
 const routes: Routes = [
   { path: '', component: CreateVchWizardComponent },
@@ -57,7 +58,8 @@ const routes: Routes = [
     SummaryComponent
   ],
   providers: [
-    CreateVchWizardService
+    CreateVchWizardService,
+    VicVmViewService
   ],
   exports: [
     CreateVchWizardComponent,

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.service.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.service.spec.ts
@@ -16,30 +16,120 @@
 import { TestBed, async } from '@angular/core/testing';
 import { Observable } from 'rxjs/Observable';
 import {
-    BaseRequestOptions,
-    ConnectionBackend,
-    RequestOptions,
-    Http,
-    Response,
-    ResponseOptions,
-    ResponseType,
-    XHRBackend,
-    Headers
+  BaseRequestOptions,
+  ConnectionBackend,
+  RequestOptions,
+  Http,
+  Response,
+  ResponseOptions,
 } from '@angular/http';
 import { MockBackend, MockConnection } from '@angular/http/testing';
 import { JASMINE_TIMEOUT } from '../testing/jasmine.constants';
 import { CreateVchWizardService } from './create-vch-wizard.service';
 import { Globals, GlobalsService } from '../shared';
 import {
-  clusterHostsChilds,
-  computeResourcesRealName,
-  dcClustersAndStandAloneHosts,
-  dcDSwitchPorGroupsList, dcMockData, dvsHostsEntries,
-  folderDSwitchList, folderDSwitchPorGroupsList,
-  netWorkingResources
+  folderDSwitchList,
+  netWorkingResources,
+  folderDSwitchPorGroupsList,
+  hostResourceBasicInfos,
+  dcDSwitchPorGroupsList,
+  dvsHostsEntriesList,
+  hostComputeResources,
+  clusterComputeResources,
+  clusterResourceBasicInfos,
+  dcComputeResources,
+  rpResourceBasicInfos,
+  rpComputeResources
 } from './mocks/create-vch-wizard-mocked-data';
-import {ComputeResource} from '../interfaces/compute.resource';
-import {COMPUTE_RESOURCE_NODE_TYPES} from '../shared/constants';
+import { ComputeResource } from '../interfaces/compute.resource';
+import { COMPUTE_RESOURCE_NODE_TYPES } from '../shared/constants';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { VicVmViewService } from '../services/vm-view.service';
+import { getMorIdFromObjRef, resourceIsCluster, resourceIsHost, resourceIsResourcePool } from '../shared/utils/object-reference';
+
+const clusterHostsChilds = Observable.of([hostResourceBasicInfos[4]]);
+const observableFolderDSwitchPorGroupsList = [
+  Observable.of([
+    folderDSwitchPorGroupsList[0],
+    folderDSwitchPorGroupsList[1],
+    folderDSwitchPorGroupsList[2]
+  ]),
+  Observable.of([
+    folderDSwitchPorGroupsList[3],
+    folderDSwitchPorGroupsList[4],
+    folderDSwitchPorGroupsList[5]
+  ])
+];
+const observableDcDSwitchPorGroupsList = [
+  Observable.of([
+    dcDSwitchPorGroupsList[0],
+    dcDSwitchPorGroupsList[1]
+  ]),
+  Observable.of([
+    dcDSwitchPorGroupsList[2],
+    dcDSwitchPorGroupsList[3],
+    dcDSwitchPorGroupsList[4]
+  ])
+];
+const ObservableDvsHostsEntriesList = [
+  Observable.of([
+    dvsHostsEntriesList[0]
+  ]),
+  Observable.of([
+    dvsHostsEntriesList[1],
+    dvsHostsEntriesList[2]
+  ]),
+  Observable.of([
+    dvsHostsEntriesList[3]
+  ]),
+  Observable.of([
+    dvsHostsEntriesList[4]
+  ])
+];
+const ObservableFolderDSwitchList = Observable.of(folderDSwitchList);
+const ObservableNetWorkingResources = Observable.of(netWorkingResources);
+
+const resourceCompleteInfoProps = 'name,parent,resourcePool';
+const clustersAndStandaloneHostsProps = 'host,cluster';
+const hostsProps = 'host';
+const resourcePoolProps = 'resourcePool';
+function getResourcePropertiesResponse(objRef: string, requestedProps: string) {
+  let responseObject: any;
+  const resourcesSource = hostComputeResources
+    .concat(clusterComputeResources)
+    .concat(rpComputeResources);
+  switch (requestedProps) {
+    case resourceCompleteInfoProps:
+      const objValue = getMorIdFromObjRef(objRef);
+      const completeResourceInfo = resourcesSource.find(resource => resource.value === objValue);
+      responseObject = {
+        name: completeResourceInfo.name,
+        parent: completeResourceInfo.parent,
+        resourcePool: completeResourceInfo.resourcePool
+      };
+      break;
+    case clustersAndStandaloneHostsProps:
+      responseObject = {
+        host: hostResourceBasicInfos,
+        cluster: clusterResourceBasicInfos,
+      };
+      break;
+    case hostsProps:
+      const childHosts = hostComputeResources
+        .filter(host => host.parent && host.parent.value === getMorIdFromObjRef(objRef))
+        .map(hostResource => hostResourceBasicInfos.find(basicHost => basicHost.value === hostResource.value));
+      responseObject = {
+        host: childHosts
+      };
+      break;
+    case resourcePoolProps:
+      responseObject = {
+        resourcePool: rpResourceBasicInfos
+      };
+      break;
+  }
+  return Observable.of(responseObject);
+}
 
 describe('CreateVchWizardService', () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = JASMINE_TIMEOUT;
@@ -49,13 +139,18 @@ describe('CreateVchWizardService', () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
+            imports: [
+              HttpClientModule,
+            ],
             providers: [
                 CreateVchWizardService,
                 Http,
                 { provide: ConnectionBackend, useClass: MockBackend },
                 { provide: RequestOptions, useClass: BaseRequestOptions },
                 Globals,
-                GlobalsService
+                GlobalsService,
+                HttpClient,
+                VicVmViewService
             ]
         }).compileComponents();
         service = TestBed.get(CreateVchWizardService);
@@ -126,13 +221,21 @@ describe('CreateVchWizardService', () => {
     });
 
     it('should retrieve a list of distributed port groups', async() => {
-      spyOn(service, 'getNetworkingTree').and.returnValue(Observable.of(netWorkingResources));
-      spyOn<any>(service, 'getDvsFromNetworkFolders').and.returnValue(Observable.of(folderDSwitchList));
-      spyOn<any>(service, 'getDvsPortGroups').and.returnValue([...folderDSwitchPorGroupsList, ...dcDSwitchPorGroupsList]);
-      spyOn<any>(service, 'getDvsHostsEntries').and.returnValue(dvsHostsEntries);
+      spyOn(service, 'getNetworkingTree').and.returnValue(ObservableNetWorkingResources);
+      spyOn<any>(service, 'getDvsFromNetworkFolders').and.returnValue(ObservableFolderDSwitchList);
+      spyOn<any>(service, 'getDvsHostsEntries').and.returnValue(ObservableDvsHostsEntriesList);
       spyOn<any>(service, 'getHostsFromComputeResource').and.returnValue(clusterHostsChilds);
+      spyOn<any>(service, 'getDvsPortGroups').and
+        .returnValue([...observableFolderDSwitchPorGroupsList, ...observableDcDSwitchPorGroupsList]);
 
-      const selectedHostResource: ComputeResource = {
+      const serverInfoServiceGui = ' d7c361cc-0a46-441e-8e21-ac22debf7003';
+      const selectedClusterResource1: ComputeResource = {
+        serverGuid: serverInfoServiceGui,
+        value: 'domain-c276',
+        type: 'ClusterComputeResource',
+        name: '10.192.109.234',
+        parent: null,
+        resourcePool: null,
         text: '10.192.109.234',
         nodeTypeId: COMPUTE_RESOURCE_NODE_TYPES.host.dc_stand_alone,
         objRef: 'urn:vmomi:ClusterComputeResource:host-276:d7c361cc-0a46-441e-8e21-ac22debf7003',
@@ -140,7 +243,13 @@ describe('CreateVchWizardService', () => {
         isEmpty: true
       };
 
-      const selectedClusterResource: ComputeResource = {
+      const selectedClusterResource2: ComputeResource = {
+        serverGuid: serverInfoServiceGui,
+        value: 'domain-c270',
+        type: 'ClusterComputeResource',
+        name: 'New Cluster',
+        parent: null,
+        resourcePool: null,
         text: 'New Cluster',
         nodeTypeId: COMPUTE_RESOURCE_NODE_TYPES.cluster.dc_cluster,
         objRef: 'urn:vmomi:ClusterComputeResource:domain-c270:d7c361cc-0a46-441e-8e21-ac22debf7003',
@@ -148,29 +257,102 @@ describe('CreateVchWizardService', () => {
         isEmpty: true
       };
 
-      service.getDistributedPortGroups(null, selectedHostResource)
+      service.getDistributedPortGroups(null, selectedClusterResource1)
         .subscribe(data => {
           expect(data.length).toBe(3);
         });
 
-      service.getDistributedPortGroups(null, selectedClusterResource)
+      service.getDistributedPortGroups(null, selectedClusterResource2)
         .subscribe(data => {
           expect(data.length).toBe(3);
         });
     });
 
-    it('should return a list of Compute Resources with a property called realName', async() => {
-      spyOn(service, 'getDatacenter').and.returnValue(Observable.of(dcMockData));
-      spyOn<any>(service, 'getDcClustersAndStandAloneHosts').and.returnValue(Observable.of(dcClustersAndStandAloneHosts));
-      spyOn<any>(service, 'getComputeResourceRealName').and.returnValue(Observable.of(computeResourcesRealName[0]));
+    it('should retrieve a ComputeResource from a ResourceBasicInfo', async() => {
+      const basicResourceInfo = hostResourceBasicInfos[0];
+      const expectedCompleteResourceInfo = hostComputeResources
+        .find(resource => resource.value === basicResourceInfo.value);
+      spyOn<any>(service, 'getResourceProperties').and.callFake(getResourcePropertiesResponse);
 
-      service.getClustersList(null)
-        .subscribe(data => {
-          expect(data.length).toBe(1);
-          expect(data[0].realName).toBeTruthy();
-          expect(data[0].realName).toBe(computeResourcesRealName[0].name);
-        });
+      service.getResourceCompleteInfo(basicResourceInfo)
+        .subscribe((data: ComputeResource) => {
+          expect(data.name).toBe(expectedCompleteResourceInfo.name);
+          expect(data.parent).toBe(expectedCompleteResourceInfo.parent);
+          expect(data.resourcePool).toBe(expectedCompleteResourceInfo.resourcePool);
+          expect(data.objRef).toBe(expectedCompleteResourceInfo.objRef);
+          expect(data.text).toBe(expectedCompleteResourceInfo.text);
+        })
+    });
 
+    it('should retrieve a ComputeResource list from a ResourceBasicInfo list', async() => {
+      spyOn<any>(service, 'getResourceProperties').and.callFake(getResourcePropertiesResponse);
+
+      service.getResourcesCompleteInfo(hostResourceBasicInfos)
+        .subscribe((data: ComputeResource[]) => {
+          expect(data.length).toBe(hostResourceBasicInfos.length);
+          data.forEach((resource: ComputeResource, idx: number) => {
+            expect(resource.name).toBe(hostComputeResources[idx].name);
+            expect(resource.parent).toBe(hostComputeResources[idx].parent);
+            expect(resource.resourcePool).toBe(hostComputeResources[idx].resourcePool);
+            expect(resource.objRef).toBe(hostComputeResources[idx].objRef);
+            expect(resource.text).toBe(hostComputeResources[idx].text);
+          });
+        })
+    });
+
+    it('should retrieve the requested properties', async() => {
+      spyOn<any>(service, 'getResourceProperties').and.callFake(getResourcePropertiesResponse);
+
+      service.getResourceProperties(hostComputeResources[0].objRef, resourceCompleteInfoProps)
+        .subscribe((data: any) => {
+          const expectedProperties = resourceCompleteInfoProps.split(',');
+          expectedProperties.forEach((prop: string) => {
+            expect(data.hasOwnProperty(prop)).toBe(true);
+          });
+        })
+    });
+
+    it('should return a list of Cluster and stand alone Hosts', async() => {
+      spyOn<any>(service, 'getResourceProperties').and.callFake(getResourcePropertiesResponse);
+      spyOn<any>(service, 'getResourcePoolsTree').and.returnValue(Observable.of([]));
+
+      const clusters: ComputeResource[] = clusterComputeResources;
+      const standAloneHosts: ComputeResource[] = hostComputeResources
+        .filter((rci: ComputeResource) => resourceIsHost(rci.type) && (!rci.parent || !resourceIsCluster(rci.parent.type)));
+
+      const expectedDcClustersAndStandAloneHosts = clusters.concat(standAloneHosts);
+
+        service.getDcClustersAndStandAloneHosts(dcComputeResources[0])
+        .subscribe((data: ComputeResource[]) => {
+          expect(data.length).toBe(expectedDcClustersAndStandAloneHosts.length);
+          data.forEach((resource: ComputeResource) => {
+            const parentIsCluster = resource.parent ? resourceIsCluster(resource.parent.type) : false;
+            expect(parentIsCluster).toBe(false);
+          })
+        })
+    });
+
+    it('should return a list of Hosts and ResourcePools from a Cluster', async() => {
+      spyOn<any>(service, 'getResourceProperties').and.callFake(getResourcePropertiesResponse);
+      spyOn<any>(service, 'getResourcePoolsTree').and.returnValue(Observable.of(rpComputeResources));
+
+      service.getHostsAndResourcePoolsFromCluster(clusterComputeResources[0])
+        .subscribe((data: ComputeResource[]) => {
+          const hosts = data.filter(resource => resourceIsHost(resource.type));
+          const rps = data.filter(resource => resourceIsResourcePool(resource.type));
+          expect(data.length).toBe(5);
+          expect(hosts.length).toBe(1);
+          expect(rps.length).toBe(4);
+        })
+    });
+
+    it('should not return any host from a Cluster which does not has any Host', async() => {
+      spyOn<any>(service, 'getResourceProperties').and.callFake(getResourcePropertiesResponse);
+
+      service.getHostsFromComputeResource(clusterComputeResources[1])
+        .subscribe((data: ComputeResource[]) => {
+          expect(data.length).toBe(0);
+        })
     });
 
 });

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/mocks/create-vch-wizard-mocked-data.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/mocks/create-vch-wizard-mocked-data.ts
@@ -1,5 +1,286 @@
-import {Observable} from 'rxjs/Observable';
+import {ComputeResource, ResourceBasicInfo} from '../../interfaces/compute.resource';
 
+export const serverInfoServiceGui = 'd7c361cc-0a46-441e-8e21-ac22debf7003';
+
+//  DC
+export const dcResourceBasicInfos: ResourceBasicInfo[] = [
+  {
+    serverGuid: serverInfoServiceGui,
+    value: 'datacenter-2',
+    type: 'Datacenter',
+  },
+  {
+    serverGuid: serverInfoServiceGui,
+    value: 'datacenter-52',
+    type: 'Datacenter',
+  }
+];
+export const dcComputeResources: ComputeResource[] = [
+  {
+    ...dcResourceBasicInfos[0],
+    text: 'Datacenter',
+    name: 'Datacenter',
+    parent: null,
+    resourcePool: null,
+    hasChildren: true,
+    objRef: `urn:vmomi:${dcResourceBasicInfos[0].type}:${dcResourceBasicInfos[0].value}:${dcResourceBasicInfos[0].serverGuid}`,
+    nodeTypeId: dcResourceBasicInfos[0].type,
+    isEmpty: null,
+    aliases: [
+      'urn:vmomi:Folder:group-h4:d7c361cc-0a46-441e-8e21-ac22debf7003',
+      'urn:vmomi:Folder:group-v3:d7c361cc-0a46-441e-8e21-ac22debf7003',
+      'urn:vmomi:Folder:group-s5:d7c361cc-0a46-441e-8e21-ac22debf7003',
+      'urn:vmomi:Folder:group-n6:d7c361cc-0a46-441e-8e21-ac22debf7003'
+    ]
+  },
+  {
+    ...dcResourceBasicInfos[1],
+    text: 'Datacenter 1',
+    name: 'Datacenter 1',
+    parent: null,
+    resourcePool: null,
+    hasChildren: true,
+    objRef: `urn:vmomi:${dcResourceBasicInfos[1].type}:${dcResourceBasicInfos[1].value}:${dcResourceBasicInfos[1].serverGuid}`,
+    nodeTypeId: dcResourceBasicInfos[1].type,
+    isEmpty: null,
+    aliases: [
+      'urn:vmomi:Folder:group-h54:d7c361cc-0a46-441e-8e21-ac22debf7003',
+      'urn:vmomi:Folder:group-v53:d7c361cc-0a46-441e-8e21-ac22debf7003',
+      'urn:vmomi:Folder:group-s55:d7c361cc-0a46-441e-8e21-ac22debf7003',
+      'urn:vmomi:Folder:group-n56:d7c361cc-0a46-441e-8e21-ac22debf7003'
+    ]
+  }
+];
+export const datacenter: ComputeResource = dcComputeResources[0];
+export const datacenter1: ComputeResource = dcComputeResources[1];
+
+// Host
+export const hostResourceBasicInfos: ResourceBasicInfo[] = [
+  {
+    serverGuid: serverInfoServiceGui,
+    value: 'host-94',
+    type: 'HostSystem',
+  },
+  {
+    serverGuid: serverInfoServiceGui,
+    value: 'host-20',
+    type: 'HostSystem',
+  },
+  {
+    serverGuid: serverInfoServiceGui,
+    value: 'host-9',
+    type: 'HostSystem',
+  },
+  {
+    serverGuid: serverInfoServiceGui,
+    value: 'host-101',
+    type: 'HostSystem',
+  },
+  {
+    serverGuid: serverInfoServiceGui,
+    value: 'host-276',
+    type: 'HostSystem'
+  }
+];
+export const hostComputeResources: ComputeResource[] = [
+  {
+    ...hostResourceBasicInfos[0],
+    name: '10.192.109.234',
+    parent: {
+      serverGuid: serverInfoServiceGui,
+      value: 'domain-c23',
+      type: 'ClusterComputeResource',
+    },
+    resourcePool: null,
+    text: '10.192.109.234',
+    hasChildren: true,
+    objRef: `urn:vmomi:${hostResourceBasicInfos[0].type}:${hostResourceBasicInfos[0].value}:${hostResourceBasicInfos[0].serverGuid}`,
+    nodeTypeId: hostResourceBasicInfos[0].type,
+    aliases: ['urn:vmomi:ResourcePool:resgroup-93:d7c361cc-0a46-441e-8e21-ac22debf7003'],
+    datacenterObjRef: 'urn:vmomi:Datacenter:datacenter-2:d7c361cc-0a46-441e-8e21-ac22debf7003'
+  },
+  {
+    ...hostResourceBasicInfos[1],
+    name: '10.161.251.202',
+    parent: null,
+    resourcePool: null,
+    text: '10.161.251.202',
+    hasChildren: false,
+    objRef: `urn:vmomi:${hostResourceBasicInfos[1].type}:${hostResourceBasicInfos[1].value}:${hostResourceBasicInfos[1].serverGuid}`,
+    nodeTypeId: hostResourceBasicInfos[1].type,
+    aliases: null
+  },
+  {
+    ...hostResourceBasicInfos[2],
+    name: '10.162.17.176',
+    parent: null,
+    resourcePool: null,
+    text: '10.162.17.176',
+    hasChildren: false,
+    objRef: `urn:vmomi:${hostResourceBasicInfos[2].type}:${hostResourceBasicInfos[2].value}:${hostResourceBasicInfos[2].serverGuid}`,
+    nodeTypeId: hostResourceBasicInfos[2].type,
+    aliases: null
+  },
+  {
+    ...hostResourceBasicInfos[3],
+    name: '10.192.115.9',
+    parent: null,
+    resourcePool: null,
+    text: '10.192.115.9',
+    hasChildren: false,
+    objRef: `urn:vmomi:${hostResourceBasicInfos[3].type}:${hostResourceBasicInfos[3].value}:${hostResourceBasicInfos[3].serverGuid}`,
+    nodeTypeId: hostResourceBasicInfos[3].type,
+    aliases: null
+  },
+  {
+    ...hostResourceBasicInfos[4],
+    name: '10.192.115.91',
+    parent: null,
+    resourcePool: null,
+    text: '10.192.115.91',
+    hasChildren: false,
+    objRef: `urn:vmomi:${hostResourceBasicInfos[4].type}:${hostResourceBasicInfos[4].value}:${hostResourceBasicInfos[4].serverGuid}`,
+    nodeTypeId: hostResourceBasicInfos[4].type,
+    aliases: null
+  }
+];
+
+// Cluster
+export const clusterResourceBasicInfos: ResourceBasicInfo[] = [
+  {
+    serverGuid: serverInfoServiceGui,
+    value: 'domain-c23',
+    type: 'ClusterComputeResource',
+  },
+  {
+    serverGuid: serverInfoServiceGui,
+    value: 'domain-c98',
+    type: 'ClusterComputeResource',
+  }
+];
+export const clusterComputeResources: ComputeResource[] = [
+  {
+    ...clusterResourceBasicInfos[0],
+    name: 'New Cluster',
+    parent: null,
+    resourcePool: null,
+    text: 'New Cluster',
+    hasChildren: true,
+    objRef:
+      `urn:vmomi:${clusterResourceBasicInfos[0].type}:${clusterResourceBasicInfos[0].value}:${clusterResourceBasicInfos[0].serverGuid}`,
+    nodeTypeId: clusterResourceBasicInfos[0].type,
+    aliases: ['urn:vmomi:ResourcePool:resgroup-24:d7c361cc-0a46-441e-8e21-ac22debf7003'],
+    datacenterObjRef: 'urn:vmomi:Datacenter:datacenter-2:d7c361cc-0a46-441e-8e21-ac22debf7003'
+  },
+  {
+    ...clusterResourceBasicInfos[1],
+    name: 'New Cluster 1',
+    parent: null,
+    resourcePool: null,
+    text: 'New Cluster 1',
+    hasChildren: true,
+    objRef:
+      `urn:vmomi:${clusterResourceBasicInfos[1].type}:${clusterResourceBasicInfos[1].value}:${clusterResourceBasicInfos[1].serverGuid}`,
+    nodeTypeId: clusterResourceBasicInfos[1].type,
+    aliases: ['urn:vmomi:ResourcePool:resgroup-99:d7c361cc-0a46-441e-8e21-ac22debf7003'],
+    datacenterObjRef: 'urn:vmomi:Datacenter:datacenter-52:d7c361cc-0a46-441e-8e21-ac22debf7003'
+  }
+];
+export const mockedDcClustersAndStandAloneHostsList: ComputeResource[] = [
+  clusterComputeResources[0],
+  hostComputeResources[0],
+  clusterComputeResources[1]
+];
+export const mockedClusterHostsList1: ComputeResource[] = [
+  hostComputeResources[1],
+  hostComputeResources[2]
+];
+export const mockedClusterHostsList2: ComputeResource[] = [
+  hostComputeResources[3]
+];
+
+// ResourcePools
+export const rpResourceBasicInfos: ResourceBasicInfo[] = [
+  {
+    serverGuid: serverInfoServiceGui,
+    value: 'resgroup-389',
+    type: 'ResourcePool',
+  },
+  {
+    serverGuid: serverInfoServiceGui,
+    value: 'resgroup-340',
+    type: 'ResourcePool',
+  },
+  {
+    serverGuid: serverInfoServiceGui,
+    value: 'resgroup-337',
+    type: 'ResourcePool',
+  },
+  {
+    serverGuid: serverInfoServiceGui,
+    value: 'resgroup-350',
+    type: 'ResourcePool',
+  }
+];
+export const rpComputeResources: ComputeResource[] = [
+  {
+    ...rpResourceBasicInfos[0],
+    name: 'ResourcePool 1',
+    parent: null,
+    resourcePool: null,
+    text: 'ResourcePool 1',
+    hasChildren: true,
+    objRef: `urn:vmomi:${rpResourceBasicInfos[0].type}:${rpResourceBasicInfos[0].value}:${rpResourceBasicInfos[0].serverGuid}`,
+    nodeTypeId: rpResourceBasicInfos[0].type,
+    aliases: ['urn:vmomi:ResourcePool:resgroup-24:d7c361cc-0a46-441e-8e21-ac22debf7003'],
+    datacenterObjRef: 'urn:vmomi:Datacenter:datacenter-2:d7c361cc-0a46-441e-8e21-ac22debf7003'
+  },
+  {
+    ...rpResourceBasicInfos[1],
+    name: 'ResourcePool 2',
+    parent: null,
+    resourcePool: null,
+    text: 'ResourcePool 2',
+    hasChildren: true,
+    objRef: `urn:vmomi:${rpResourceBasicInfos[1].type}:${rpResourceBasicInfos[1].value}:${rpResourceBasicInfos[1].serverGuid}`,
+    nodeTypeId: rpResourceBasicInfos[1].type,
+    aliases: ['urn:vmomi:ResourcePool:resgroup-24:d7c361cc-0a46-441e-8e21-ac22debf7003'],
+    datacenterObjRef: 'urn:vmomi:Datacenter:datacenter-2:d7c361cc-0a46-441e-8e21-ac22debf7003'
+  },
+  {
+    ...rpResourceBasicInfos[2],
+    name: 'ResourcePool 3',
+    parent: null,
+    resourcePool: null,
+    text: 'ResourcePool 3',
+    hasChildren: true,
+    objRef: `urn:vmomi:${rpResourceBasicInfos[2].type}:${rpResourceBasicInfos[2].value}:${rpResourceBasicInfos[2].serverGuid}`,
+    nodeTypeId: rpResourceBasicInfos[2].type,
+    aliases: ['urn:vmomi:ResourcePool:resgroup-24:d7c361cc-0a46-441e-8e21-ac22debf7003'],
+    datacenterObjRef: 'urn:vmomi:Datacenter:datacenter-2:d7c361cc-0a46-441e-8e21-ac22debf7003'
+  },
+  {
+    ...rpResourceBasicInfos[3],
+    name: 'ResourcePool 4',
+    parent: null,
+    resourcePool: null,
+    text: 'ResourcePool 4',
+    hasChildren: true,
+    objRef: `urn:vmomi:${rpResourceBasicInfos[3].type}:${rpResourceBasicInfos[3].value}:${rpResourceBasicInfos[3].serverGuid}`,
+    nodeTypeId: rpResourceBasicInfos[3].type,
+    aliases: ['urn:vmomi:ResourcePool:resgroup-24:d7c361cc-0a46-441e-8e21-ac22debf7003'],
+    datacenterObjRef: 'urn:vmomi:Datacenter:datacenter-2:d7c361cc-0a46-441e-8e21-ac22debf7003'
+  }
+];
+
+// Vic RPools
+export const vicResourcePoolList: string[] = [
+  'resPoolName1',
+  'resPoolName2',
+  'resPoolName3'
+];
+
+// Networking
 export const netWorkingResources = [
   {
     text: 'bug-389',
@@ -42,7 +323,6 @@ export const netWorkingResources = [
     aliases: null
   }
 ];
-
 export const folderDSwitchList = [
   {
     text: 'DSwitch-bug-389',
@@ -61,9 +341,8 @@ export const folderDSwitchList = [
     aliases: null
   }
 ];
-
 export const folderDSwitchPorGroupsList = [
-  Observable.of([{
+  {
     text: 'DPG-bug-389-1',
     spriteCssClass: 'vsphere-icon-virtual-port-group',
     hasChildren: false,
@@ -86,8 +365,8 @@ export const folderDSwitchPorGroupsList = [
     objRef: 'urn:vmomi:DistributedVirtualPortgroup:dvportgroup-83:d7c361cc-0a46-441e-8e21-ac22debf7003',
     nodeTypeId: 'DvsDvpg',
     aliases: null
-  }]),
-  Observable.of([{
+  },
+  {
     text: 'DSwitch-bug-389-test-1',
     spriteCssClass: 'vsphere-icon-virtual-port-group',
     hasChildren: false,
@@ -110,11 +389,10 @@ export const folderDSwitchPorGroupsList = [
     objRef: 'urn:vmomi:DistributedVirtualPortgroup:dvportgroup-87:d7c361cc-0a46-441e-8e21-ac22debf7003',
     nodeTypeId: 'DvsDvpg',
     aliases: null
-  }])
+  }
 ];
-
 export const dcDSwitchPorGroupsList = [
-  Observable.of([{
+  {
     text: 'DPortGroup-DS1-1',
     spriteCssClass: 'vsphere-icon-virtual-port-group',
     hasChildren: false,
@@ -129,8 +407,8 @@ export const dcDSwitchPorGroupsList = [
     objRef: 'urn:vmomi:DistributedVirtualPortgroup:dvportgroup-30:d7c361cc-0a46-441e-8e21-ac22debf7003',
     nodeTypeId: 'DvsDvpg',
     aliases: null
-  }]),
-  Observable.of([{
+  },
+  {
     text: 'DPortGroup-DS2-1',
     spriteCssClass: 'vsphere-icon-virtual-port-group',
     hasChildren: false,
@@ -153,82 +431,32 @@ export const dcDSwitchPorGroupsList = [
     objRef: 'urn:vmomi:DistributedVirtualPortgroup:dvportgroup-26:d7c361cc-0a46-441e-8e21-ac22debf7003',
     nodeTypeId: 'DvsDvpg',
     aliases: null
-  }])
-];
-
-export const dvsHostsEntries = [
-  Observable.of([
-    {
-      serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
-      type: 'HostSystem',
-      value: 'host-276'
-    }
-  ]),
-  Observable.of([
-    {
-      serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
-      type: 'HostSystem',
-      value: 'host-277'
-    },
-    {
-      serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
-      type: 'HostSystem',
-      value: 'host-278'
-    }
-  ]),
-  Observable.of([
-    {
-      serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
-      type: 'HostSystem',
-      value: 'host-279'
-    }
-  ]),
-  Observable.of([
-    {
-      serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
-      type: 'HostSystem',
-      value: 'host-280'
-    }
-  ])
-];
-
-export const clusterHostsChilds = Observable.of([
-    {
-      serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
-      type: 'HostSystem',
-      value: 'host-276'
-    }
-]);
-
-export const dcMockData = [
-  {
-    text: 'ha-datacenter',
-    spriteCssClass: 'vsphere-icon-datacenter',
-    hasChildren: true,
-    objRef: 'urn:vmomi:Datacenter:datacenter-2:196f7764-7aec-42d8-9def-6b5899b7e0e1',
-    nodeTypeId: 'Datacenter',
-    aliases: [
-      'urn:vmomi:Folder:group-h4:196f7764-7aec-42d8-9def-6b5899b7e0e1',
-      'urn:vmomi:Folder:group-v3:196f7764-7aec-42d8-9def-6b5899b7e0e1',
-      'urn:vmomi:Folder:group-s5:196f7764-7aec-42d8-9def-6b5899b7e0e1',
-      'urn:vmomi:Folder:group-n6:196f7764-7aec-42d8-9def-6b5899b7e0e1']
   }
 ];
-
-export const dcClustersAndStandAloneHosts = [
+export const dvsHostsEntriesList: ResourceBasicInfo[] = [
   {
-    text: '10.161.75.158 (Reboot Required)',
-    spriteCssClass: 'vsphere-icon-host-warning',
-    hasChildren: true,
-    objRef: 'urn:vmomi:HostSystem:host-15:196f7764-7aec-42d8-9def-6b5899b7e0e1',
-    nodeTypeId: 'DcStandaloneHost',
-    aliases: ['urn:vmomi:ResourcePool:resgroup-14:196f7764-7aec-42d8-9def-6b5899b7e0e1']
-  }
-];
-
-export const computeResourcesRealName = [
+    serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
+    type: 'HostSystem',
+    value: 'host-276'
+  },
   {
-    name: '10.161.75.158',
-    id: 'urn:vmomi:HostSystem:host-15:196f7764-7aec-42d8-9def-6b5899b7e0e1'
+    serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
+    type: 'HostSystem',
+    value: 'host-277'
+  },
+  {
+    serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
+    type: 'HostSystem',
+    value: 'host-278'
+  },
+  {
+    serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
+    type: 'HostSystem',
+    value: 'host-279'
+  },
+  {
+    serverGuid: 'd7c361cc-0a46-441e-8e21-ac22debf7003',
+    type: 'HostSystem',
+    value: 'host-280'
   }
 ];

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.spec.ts
@@ -20,6 +20,7 @@ import {HttpModule} from '@angular/http';
 import {CreateVchWizardService} from '../create-vch-wizard.service';
 import {Observable} from 'rxjs/Observable';
 import {NetworksComponent} from './networks.component';
+import {mockedDcClustersAndStandAloneHostsList} from '../mocks/create-vch-wizard-mocked-data';
 
 describe('NetworksComponent', () => {
 
@@ -60,6 +61,7 @@ describe('NetworksComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(NetworksComponent);
     component = fixture.componentInstance;
+    component.resourceObj = mockedDcClustersAndStandAloneHostsList[0];
     component.onPageLoad();
 
     service = fixture.debugElement.injector.get(CreateVchWizardService);

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.ts
@@ -25,6 +25,7 @@ import {
   ipListPattern, cidrListPattern
 } from '../../shared/utils/validators';
 import { ComputeResource } from '../../interfaces/compute.resource';
+import { resourceIsResourcePool } from '../../shared/utils/object-reference';
 
 @Component({
   selector: 'vic-vch-creation-networks',
@@ -139,8 +140,11 @@ export class NetworksComponent implements OnInit {
   }
 
   loadPortgroups(computeResourceObj: ComputeResource) {
+    const selectedComputeResource: ComputeResource = !resourceIsResourcePool(computeResourceObj.type) ?
+      computeResourceObj : computeResourceObj.rootParentComputeResource;
+
     this.portgroupsLoading = true;
-    this.createWzService.getDistributedPortGroups(this.datacenter, computeResourceObj)
+    this.createWzService.getDistributedPortGroups(this.datacenter, selectedComputeResource)
       .subscribe(v => {
         this.portgroups = v;
         this.form.get('bridgeNetwork').setValue('');

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/security/security.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/security/security.component.spec.ts
@@ -81,6 +81,12 @@ describe('SecurityComponent', () => {
     component.vchName = 'vch-example-name';
     component.onPageLoad();
     component.datacenter = {
+      serverGuid: 'aaaa-bbb-ccc',
+      value: 'dc-test',
+      type: 'Datacenter',
+      name: 'Test DC',
+      parent: null,
+      resourcePool: null,
       objRef: 'urn:vmomi:Datacenter:dc-test:aaaa-bbb-ccc',
       text: 'Test DC',
       nodeTypeId: 'test',

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/storage-capacity/storage-capacity.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/storage-capacity/storage-capacity.component.ts
@@ -23,6 +23,8 @@ import {
 import { Observable } from 'rxjs/Observable';
 import { CreateVchWizardService } from '../create-vch-wizard.service';
 import { supportedCharsPattern, numberPattern } from '../../shared/utils/validators';
+import { ComputeResource } from '../../interfaces/compute.resource';
+import { resourceIsResourcePool } from '../../shared/utils/object-reference';
 
 @Component({
   selector: 'vic-vch-creation-storage-capacity',
@@ -35,9 +37,9 @@ export class StorageCapacityComponent implements OnInit {
   public datastores: any[] = [];
   public datastoresLoading = true;
   private _isSetup = false;
-  @Input() set resourceObjRef(value) {
-    if (typeof value !== 'undefined') {
-      this.loadDatastore(value);
+  @Input() set resourceObjRef(obj: ComputeResource) {
+    if (typeof obj !== 'undefined') {
+      this.loadDatastore(!resourceIsResourcePool(obj.type) ? obj.objRef : obj.rootParentComputeResource.objRef);
     }
   }
 
@@ -84,7 +86,7 @@ export class StorageCapacityComponent implements OnInit {
     });
   }
 
-  loadDatastore(resource) {
+  loadDatastore(resource: string) {
     this.datastoresLoading = true;
     this.createWzService.getDatastores(resource)
       .subscribe(v => {

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/summary/summary.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/summary/summary.html
@@ -39,7 +39,7 @@
           <clr-stack-block>
             <clr-stack-label>Cluster/Resource pool</clr-stack-label>
             <clr-stack-content>
-              {{ payload?.computeCapacity?.computeResource }}
+              {{ payload?.computeCapacity?.computeResourceName }}
             </clr-stack-content>
           </clr-stack-block>
           <!-- cpu -->

--- a/h5c/vic/src/vic-webapp/src/app/interfaces/api-responses.ts
+++ b/h5c/vic/src/vic-webapp/src/app/interfaces/api-responses.ts
@@ -1,5 +1,0 @@
-export interface HostTypeInfo {
-  serverGuid: string;
-  type: string;
-  value: string;
-}

--- a/h5c/vic/src/vic-webapp/src/app/interfaces/compute.resource.ts
+++ b/h5c/vic/src/vic-webapp/src/app/interfaces/compute.resource.ts
@@ -14,11 +14,24 @@
  limitations under the License.
 */
 
-export interface ComputeResource {
-  text: string;
-  nodeTypeId: string;
-  objRef: string;
-  aliases: string[];
-  isEmpty: boolean;
-  realName?: string;
+export interface ResourceBasicInfo {
+  serverGuid: string;
+  type: string;
+  value: string;
+}
+
+export interface ComputeResource extends ResourceBasicInfo {
+  name: string;
+  parent: ResourceBasicInfo,
+  resourcePool: ResourceBasicInfo,
+  id?: string;
+  objRef?: string;
+  text?: string;
+  datacenterObjRef?: string;
+  isEmpty?: boolean;
+  childs?: ResourceBasicInfo[];
+  aliases?: string[];
+  nodeTypeId?: string;
+  rootParentComputeResource?: ComputeResource;
+  hasChildren?: boolean;
 }

--- a/h5c/vic/src/vic-webapp/src/app/shared/constants/nodetype.ts
+++ b/h5c/vic/src/vic-webapp/src/app/shared/constants/nodetype.ts
@@ -27,11 +27,13 @@ export const COMPUTE_RESOURCE_NODE_TYPES = {
   },
   host: {
     dc_stand_alone: 'DcStandaloneHost',
-    cluster_host: 'ClusterHostSystem'
+    cluster_host: 'ClusterHostSystem',
+    host_system: 'HostSystem',
   },
   cluster: {
     dc_cluster: 'DcCluster',
-    folder_cluster: 'CompResFolderCluster'
+    folder_cluster: 'CompResFolderCluster',
+    cluster_compute_resource: 'ClusterComputeResource',
   },
   resource_pool: {
     resource_pool: 'ResourcePool',

--- a/h5c/vic/src/vic-webapp/src/app/shared/utils/object-reference.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/shared/utils/object-reference.spec.ts
@@ -20,6 +20,12 @@ import { getVchResponseStub } from '../../services/mocks/vch.response';
 
 describe('Object Reference utility functions', () => {
   const mor = {
+    serverGuid: 'aaaa-bbb-ccc',
+    value: 'dc-test',
+    type: 'Datacenter',
+    name: 'Test DC',
+    parent: null,
+    resourcePool: null,
     objRef: 'urn:vmomi:Datacenter:dc-test:aaaa-bbb-ccc',
     text: 'Test DC',
     nodeTypeId: 'test',

--- a/h5c/vic/src/vic-webapp/src/app/shared/utils/object-reference.ts
+++ b/h5c/vic/src/vic-webapp/src/app/shared/utils/object-reference.ts
@@ -17,7 +17,8 @@ import { VirtualContainerHost } from './../../vch-view/vch.model';
 
 import { ComputeResource } from './../../interfaces/compute.resource';
 import { ServerInfo } from '../vSphereClientSdkTypes';
-import {COMPUTE_RESOURCE_NODE_TYPES} from '../constants';
+import { COMPUTE_RESOURCE_NODE_TYPES } from '../constants';
+import {globalProperties} from '../../../environments/global-properties';
 
 export function getServerServiceGuidFromObj (obj: ComputeResource): string {
   return obj.objRef.split(':')[4];
@@ -64,6 +65,27 @@ export function isDesiredType(type: string, types: string[]): boolean {
 export function resourceIsCluster(type: string): boolean {
   return isDesiredType(type, [
     COMPUTE_RESOURCE_NODE_TYPES.cluster.dc_cluster,
-    COMPUTE_RESOURCE_NODE_TYPES.cluster.folder_cluster
+    COMPUTE_RESOURCE_NODE_TYPES.cluster.folder_cluster,
+    COMPUTE_RESOURCE_NODE_TYPES.cluster.cluster_compute_resource
   ]);
 }
+
+export function resourceIsHost(type: string): boolean {
+  return isDesiredType(type, [
+    COMPUTE_RESOURCE_NODE_TYPES.host.dc_stand_alone,
+    COMPUTE_RESOURCE_NODE_TYPES.host.cluster_host,
+    COMPUTE_RESOURCE_NODE_TYPES.host.host_system
+  ]);
+}
+
+export function resourceIsResourcePool(type: string): boolean {
+  return isDesiredType(type, [
+    COMPUTE_RESOURCE_NODE_TYPES.resource_pool.vic_vch_resource_pool,
+    COMPUTE_RESOURCE_NODE_TYPES.resource_pool.resource_pool_resource_pool,
+    COMPUTE_RESOURCE_NODE_TYPES.resource_pool.resource_pool,
+    COMPUTE_RESOURCE_NODE_TYPES.resource_pool.cluster_resource_pool,
+    COMPUTE_RESOURCE_NODE_TYPES.resource_pool.host_resource_pool
+  ]);
+}
+
+

--- a/h5c/vic/src/vic-webapp/src/app/vch-view/vch.model.ts
+++ b/h5c/vic/src/vic-webapp/src/app/vch-view/vch.model.ts
@@ -71,4 +71,9 @@ export class VirtualContainerHost implements VirtualMachine {
   get vchVmId(): string {
     return this._vchVmId;
   }
+
+  get parentValue(): string {
+    return this._parentObj.value;
+  }
+
 }


### PR DESCRIPTION
This change will introduce a new logic into the resource tree selector component in order to allow users to be able to select Clusters within folders and also non-vic ResourcePools

NOTE: This is still pending to be manually tested and merged till API changes are fixed and merged into master: vmware/vic#6711

Fixes #468

PR acceptance checklist:

[ x ] All unit tests pass
[ n/a ] All e2e tests pass
[ x ] Unit test(s) included*
[ n/a ] e2e test(s) included*
[ n/a ] Screenshot attached and UX approved*

*if applicable, add n/a if not