### PR TITLE
Specify that server key file must be unencrypted

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/security/security.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/security/security.html
@@ -164,7 +164,7 @@
           <label class="required" for="tls-server-key">Server private key</label>
         </div>
         <div class="col-xs-6">
-          <span class="text-muted" *ngIf="!tlsServerKeyContents">Select encrypted key pem file</span>
+          <span class="text-muted" *ngIf="!tlsServerKeyContents">Select unencrypted key pem file</span>
           <span *ngIf="tlsServerKeyContents">
             {{ tlsServerKeyContents.name }}, algorithm: {{ tlsServerKeyContents.algorithm}}
           </span>


### PR DESCRIPTION
Contrary to what we [require](https://vmware.github.io/vic-product/assets/files/html/1.3/vic_vsphere_admin/vch_cert_options.html#server-key), the text previously stated that an "encrypted key pem file" should be selected. Correct this to indicate that an unencrypted file must be used.

Fixes #338