### PR TITLE
Fix missed service provider VicVmViewService in the app module

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/app.module.ts
+++ b/h5c/vic/src/vic-webapp/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { AppComponent } from './app.component';
 import { DisableCookieXSRFStrategy } from './shared/utils/disable-cookie-xsrf-strategy';
 import { HttpInterceptorService } from './services/http-interceptor.service';
 import { HttpClientModule } from '@angular/common/http';
+import { VicVmViewService } from './services/vm-view.service';
 
 @NgModule({
   imports: [
@@ -52,6 +53,7 @@ import { HttpClientModule } from '@angular/common/http';
     routedComponents
   ],
   providers: [
+    VicVmViewService,
     ActionDevService,
     AppAlertService,
     AppErrorHandler,


### PR DESCRIPTION
This will add a missing service provider VicVmViewService that should be added to the root app Module in order to fix VIC summary view plugin.

Fixes #578 

PR acceptance checklist:

[ x ] All unit tests pass
[ n/a ] All e2e tests pass
[ n/a ] Unit test(s) included*
[ n/a ] e2e test(s) included*
[ n/a ] Screenshot attached and UX approved*

 *if applicable, add n/a if not
