### PR TITLE
Cherry-pick: Specify that server key file must be unencrypted (#575)

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/security/security.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/security/security.html
@@ -164,7 +164,7 @@
           <label class="required" for="tls-server-key">Server private key</label>
         </div>
         <div class="col-xs-6">
-          <span class="text-muted" *ngIf="!tlsServerKeyContents">Select encrypted key pem file</span>
+          <span class="text-muted" *ngIf="!tlsServerKeyContents">Select unencrypted key pem file</span>
           <span *ngIf="tlsServerKeyContents">
             {{ tlsServerKeyContents.name }}, algorithm: {{ tlsServerKeyContents.algorithm}}
           </span>


### PR DESCRIPTION
Contrary to what we require[1], the text previously stated that an
"encrypted key pem file" should be selected. Correct this to indicate
that an unencrypted file must be used.

1 - https://vmware.github.io/vic-product/assets/files/html/1.3/vic_vsphere_admin/vch_cert_options.html#server-key

(cherry picked from commit 8c2b2043aa0bf5964a32f58bf9656be6bbce22c4)

---

PR acceptance checklist:

[ ] All unit tests pass
[ ] All e2e tests pass
[ ] Unit test(s) included*
[ ] e2e test(s) included*
[ ] Screenshot attached and UX approved*

 *if applicable, add n/a if not