### PR TITLE
fix ip VIC plugin throws a parsing error when customer tries to speci…

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.spec.ts
@@ -93,10 +93,12 @@ describe('NetworksComponent', () => {
     const managementNetworkType = component.form.get('managementNetworkType');
     const publicNetworkIp = component.form.get('publicNetworkIp');
     const clientNetworkIp = component.form.get('clientNetworkIp');
+    const clientNetworkRouting = component.form.get('clientNetworkRouting');
     const managementNetworkIp = component.form.get('managementNetworkIp');
     const publicNetworkGateway = component.form.get('publicNetworkGateway');
     const clientNetworkGateway = component.form.get('clientNetworkGateway');
     const managementNetworkGateway = component.form.get('managementNetworkGateway');
+    const managementNetworkRouting = component.form.get('managementNetworkRouting');
     const dnsServer = component.form.get('dnsServer');
 
     setDefaultRequiredValues();
@@ -142,6 +144,8 @@ describe('NetworksComponent', () => {
     clientNetworkGateway.setValue('127.0.0.1');
     managementNetworkIp.setValue('127.0.0.1/24');
     managementNetworkGateway.setValue('127.0.0.1');
+    clientNetworkRouting.setValue('127.0.0.1/24');
+    managementNetworkRouting.setValue('127.0.0.1/24');
     dnsServer.setValue('127.0.0.1');
     component.onCommit();
     expect(component.form.valid).toBe(true);

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.html
@@ -4,20 +4,18 @@
     Specify the networks used to access this virtual container host.
   </p>
 
-  <a class="btn btn-link pl-0"
-     href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_vsphere_admin/vch_networking.html"
-     target="_blank"
-  >
+  <a class="btn btn-link pl-0" href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_vsphere_admin/vch_networking.html"
+    target="_blank">
     View Network Requirements
     <clr-icon shape="pop-out"></clr-icon>
   </a>
 
   <form class="pt-0" [formGroup]="form" novalidate>
-    <section class="form-block my-0"  id='networks'>
+    <section class="form-block my-0" id='networks'>
 
       <label>Required VCH Networks</label>
-
-      <div class="row form-group mb-0">
+      <!-- start form control for bridge network -->
+      <div class="row form-group mb-0 relative-po">
         <div class="col-xs-3">
 
           <label class="required" for="bridge-network-selector">
@@ -25,7 +23,7 @@
           </label>
 
         </div>
-        <div class="col-xs">
+        <div class="col-xs-3">
 
           <div class="select form-control">
             <select id="bridge-network-selector" formControlName="bridgeNetwork">
@@ -37,7 +35,7 @@
           </div>
 
         </div>
-        <div class="col-xs text-right">
+        <div class="col-xs-3 text-right">
 
           <label for="bridge-network-range-selector">
             Bridge network range
@@ -46,16 +44,10 @@
         </div>
         <div class="col-xs">
 
-          <label for="bridge-network-range-selector"
-                 aria-haspopup="true"
-                 role="tooltip"
-                 class="tooltip tooltip-validation tooltip-lg tooltip-top-left"
-                 [class.invalid]="form.get('bridgeNetworkRange').invalid && (form.get('bridgeNetworkRange').dirty || form.get('bridgeNetworkRange').touched)">
+          <label for="bridge-network-range-selector" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-lg tooltip-top-left"
+            [class.invalid]="form.get('bridgeNetworkRange').invalid && (form.get('bridgeNetworkRange').dirty || form.get('bridgeNetworkRange').touched)">
 
-            <input id="bridge-network-range-selector"
-                   class="form-control"
-                   type="text"
-                   formControlName="bridgeNetworkRange">
+            <input id="bridge-network-range-selector" class="form-control" type="text" formControlName="bridgeNetworkRange">
 
             <span class="tooltip-content" *ngIf="form.get('bridgeNetworkRange').hasError('required')">
               Bridge network range cannot be empty
@@ -64,19 +56,20 @@
           </label>
 
         </div>
-        <div class="col-xs-1 px-0">
+        <div class="absolute-info">
 
           <clr-signpost>
             <clr-signpost-content [clrPosition]="'bottom-left'" *clrIfOpen class="bridge-network-signpost">
-              Bridge networks are the network or networks that container VMs use to communicate with each other.
-              Every virtual container host (VCH) must have a unique bridge network.
-              Do not use the bridge network for any other VM workloads, or as a bridge for more than one VCH.
+              Bridge networks are the network or networks that container VMs use to communicate with each other. Every virtual container
+              host (VCH) must have a unique bridge network. Do not use the bridge network for any other VM workloads, or
+              as a bridge for more than one VCH.
             </clr-signpost-content>
           </clr-signpost>
 
         </div>
       </div>
-
+       <!-- end form control for bridge network -->
+       <!-- start  form control for public network -->
       <div class="row form-group mb-0">
         <div class="col-xs-3">
 
@@ -85,7 +78,7 @@
           </label>
 
         </div>
-        <div class="col-xs">
+        <div class="col-xs-3">
 
           <div class="select form-control">
             <select id="public-network-selector" formControlName="publicNetwork">
@@ -97,7 +90,7 @@
           </div>
 
         </div>
-        <div class="col-xs text-right">
+        <div class="col-xs-3 text-right">
 
           <div class="radio-inline">
             <input id="pub-dhcp" type="radio" value="dhcp" formControlName="publicNetworkType">
@@ -106,23 +99,16 @@
 
           <div class="radio-inline">
             <input id="pub-static" type="radio" value="static" formControlName="publicNetworkType">
-            <label for="pub-static">Static</label>
+            <label for="pub-static">Static IP</label>
           </div>
 
         </div>
         <div class="col-xs">
 
-          <label for="public-network-ip"
-                 aria-haspopup="true"
-                 role="tooltip"
-                 class="tooltip tooltip-validation tooltip-md tooltip-top-left"
-                 [class.invalid]="form.get('publicNetworkIp').invalid && (form.get('publicNetworkIp').dirty || form.get('publicNetworkIp').touched)">
+          <label for="public-network-ip" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-top-left"
+            [class.invalid]="form.get('publicNetworkIp').invalid && (form.get('publicNetworkIp').dirty || form.get('publicNetworkIp').touched)">
 
-            <input id="public-network-ip"
-                   class="form-control"
-                   type="text"
-                   placeholder="CIDR"
-                   formControlName="publicNetworkIp">
+            <input id="public-network-ip" class="form-control" type="text" placeholder="CIDR" formControlName="publicNetworkIp">
 
             <span class="tooltip-content" *ngIf="form.get('publicNetworkIp').hasError('required')">
               Public network CIDR cannot be empty
@@ -135,7 +121,6 @@
           </label>
 
         </div>
-        <div class="col-xs-1"></div>
       </div>
 
       <div class="row form-group mb-0">
@@ -149,17 +134,10 @@
         </div>
         <div class="col-xs">
 
-          <label for="public-network-gateway"
-                 aria-haspopup="true"
-                 role="tooltip"
-                 class="tooltip tooltip-validation tooltip-md tooltip-top-left"
-                 [class.invalid]="form.get('publicNetworkGateway').invalid && (form.get('publicNetworkGateway').dirty || form.get('publicNetworkGateway').touched)">
+          <label for="public-network-gateway" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-top-left"
+            [class.invalid]="form.get('publicNetworkGateway').invalid && (form.get('publicNetworkGateway').dirty || form.get('publicNetworkGateway').touched)">
 
-            <input class="form-control"
-                   id="public-network-gateway"
-                   type="text"
-                   formControlName="publicNetworkGateway"
-                   placeholder="IP address">
+            <input class="form-control" id="public-network-gateway" type="text" formControlName="publicNetworkGateway" placeholder="IP address">
 
             <span class="tooltip-content" *ngIf="form.get('publicNetworkGateway').hasError('required')">
               Public network gateway cannot be empty
@@ -172,7 +150,7 @@
           </label>
 
         </div>
-        <div class="col-xs-1"></div>
+
       </div>
       <div class="row form-group mb-0">
         <div class="col-xs-3">
@@ -184,17 +162,10 @@
         </div>
         <div class="col-xs-5">
 
-          <label for="dns-server-selector"
-                 aria-haspopup="true"
-                 role="tooltip"
-                 class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
-                 [class.invalid]="form.get('dnsServer').invalid && (form.get('dnsServer').dirty || form.get('dnsServer').touched)">
+          <label for="dns-server-selector" aria-haspopup="true" role="tooltip" class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
+            [class.invalid]="form.get('dnsServer').invalid && (form.get('dnsServer').dirty || form.get('dnsServer').touched)">
 
-            <input id="dns-server-selector"
-                   class="form-control"
-                   placeholder="Comma separated IP addresses"
-                   type="text"
-                   formControlName="dnsServer">
+            <input id="dns-server-selector" class="form-control" placeholder="Comma separated IP addresses" type="text" formControlName="dnsServer">
 
             <span class="tooltip-content" *ngIf="form.get('dnsServer').hasError('required')">
               DNS IP addresses cannot be empty
@@ -220,14 +191,14 @@
 
     <section class="form-block" *ngIf="inAdvancedMode">
 
-    <div class="alert alert-info mb-2">
+      <div class="alert alert-info mb-2">
         <div class="alert-icon-wrapper">
           <clr-icon class="alert-icon" shape="info-circle"></clr-icon>
         </div>
         <div class="alert-text">
           The following options will be used for VCH creation only when the advanced mode is open.
         </div>
-     </div>
+      </div>
 
       <label>Optional VCH Networks</label>
 
@@ -258,8 +229,7 @@
           </small>
         </span>
 
-        <div class="col-xs text-right" *ngIf="form.get('clientNetwork').value">
-
+        <div class="col-xs-3 text-right" *ngIf="form.get('clientNetwork').value">
           <div class="radio-inline">
             <input id="client-dhcp" type="radio" value="dhcp" formControlName="clientNetworkType">
             <label for="client-dhcp">DHCP</label>
@@ -267,23 +237,15 @@
 
           <div class="radio-inline">
             <input id="client-static" type="radio" value="static" formControlName="clientNetworkType">
-            <label for="client-static">Static</label>
+            <label for="client-static">Static IP</label>
           </div>
-
         </div>
         <div class="col-xs" *ngIf="form.get('clientNetwork').value">
 
-          <label for="client-network-ip"
-                 aria-haspopup="true"
-                 role="tooltip"
-                 class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
-                 [class.invalid]="form.get('clientNetworkIp').invalid && (form.get('clientNetworkIp').dirty || form.get('clientNetworkIp').touched)">
+          <label for="client-network-ip" aria-haspopup="true" role="tooltip" class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
+            [class.invalid]="form.get('clientNetworkIp').invalid && (form.get('clientNetworkIp').dirty || form.get('clientNetworkIp').touched)">
 
-            <input class="form-control"
-                   id="client-network-ip"
-                   type="text"
-                   placeholder="CIDR"
-                   formControlName="clientNetworkIp">
+            <input class="form-control" id="client-network-ip" type="text" placeholder="CIDR" formControlName="clientNetworkIp">
 
             <span class="tooltip-content" *ngIf="form.get('clientNetworkIp').hasError('required')">
               Client network CIDR cannot be empty
@@ -296,73 +258,38 @@
           </label>
 
         </div>
-        <div class="col-xs-1"></div>
       </div>
-      <div class="row form-group mb-0" *ngIf="form.get('clientNetwork').value">
-        <div class="col-xs offset-xs-6 text-right">
-
-          <label for="client-network-gateway">
-            Gateway
+      <div class="row form-group" *ngIf="form.get('clientNetwork').value">
+        <div class="col-xs-4 text-right">
+          <label for="client-network-routing">
+            Routing destination:Gateway
           </label>
-
         </div>
-        <div class="col-xs">
+        <div class="col-xs routing-conf col-xs-8">
+          <label for="client-network-routing" aria-haspopup="true" role="tooltip" class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
+            [class.invalid]="form.get('clientNetworkRouting').invalid && (form.get('clientNetworkRouting').dirty || form.get('clientNetworkRouting').touched)">
 
-          <label for="client-network-gateway"
-                 aria-haspopup="true"
-                 role="tooltip"
-                 class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
-                 [class.invalid]="form.get('clientNetworkGateway').invalid && (form.get('clientNetworkGateway').dirty || form.get('clientNetworkGateway').touched)">
+            <input class="form-control" id="client-network-routing" type="text" placeholder="Comma delimited CIDRs" formControlName="clientNetworkRouting">
 
-            <input class="form-control"
-                   id="client-network-gateway"
-                   type="text"
-                   placeholder="IP address"
-                   formControlName="clientNetworkGateway">
+            <span class="tooltip-content" *ngIf="form.get('clientNetworkRouting').hasError('pattern')">
+              IP addresses are not valid, please input one or more routing destinations in a comma separated list, e.g. 10.1.0.0/16,10.2.0.0
+            </span>
+          </label>
+          <span>:</span>
+          <label for="client-network-gateway" aria-haspopup="true" role="tooltip" class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
+            [class.invalid]="form.get('clientNetworkGateway').invalid && (form.get('clientNetworkGateway').dirty || form.get('clientNetworkGateway').touched)">
+
+            <input class="form-control" id="client-network-gateway" type="text" placeholder="IP address" formControlName="clientNetworkGateway">
 
             <span class="tooltip-content" *ngIf="form.get('clientNetworkGateway').hasError('required')">
               Client network gateway cannot be empty
             </span>
 
             <span class="tooltip-content" *ngIf="form.get('clientNetworkGateway').hasError('pattern')">
-              Gateway address is not valid
+              Gateway address is not valid, please input ip address with format *.*.*.*. e.g. 10.1.119.23
             </span>
-
           </label>
-
         </div>
-        <div class="col-xs-1"></div>
-      </div>
-      <div class="row form-group" *ngIf="form.get('clientNetwork').value">
-        <div class="col-xs-3 text-right">
-
-          <label for="client-network-routing">
-            Routing destination
-          </label>
-
-        </div>
-        <div class="col-xs">
-
-          <label for="client-network-routing"
-                 aria-haspopup="true"
-                 role="tooltip"
-                 class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
-                 [class.invalid]="form.get('clientNetworkRouting').invalid && (form.get('clientNetworkRouting').dirty || form.get('clientNetworkRouting').touched)">
-
-            <input class="form-control"
-                   id="client-network-routing"
-                   type="text"
-                   placeholder="Comma delimited CIDRs"
-                   formControlName="clientNetworkRouting">
-
-            <span class="tooltip-content" *ngIf="form.get('clientNetworkRouting').hasError('pattern')">
-              IP addresses are not valid
-            </span>
-
-          </label>
-
-        </div>
-        <div class="col-xs-1"></div>
       </div>
 
       <div class="row form-group mb-0">
@@ -392,7 +319,7 @@
           </small>
         </span>
 
-        <div class="col-xs text-right" *ngIf="form.get('managementNetwork').value">
+        <div class="col-xs-3 text-right" *ngIf="form.get('managementNetwork').value">
 
           <div class="radio-inline">
             <input id="mgmt-dhcp" type="radio" value="dhcp" formControlName="managementNetworkType">
@@ -401,23 +328,16 @@
 
           <div class="radio-inline">
             <input id="mgmt-static" type="radio" value="static" formControlName="managementNetworkType">
-            <label for="mgmt-static">Static</label>
+            <label for="mgmt-static">Static IP</label>
           </div>
 
         </div>
         <div class="col-xs" *ngIf="form.get('managementNetwork').value">
 
-          <label for="management-network-ip"
-                 aria-haspopup="true"
-                 role="tooltip"
-                 class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
-                 [class.invalid]="form.get('managementNetworkIp').invalid && (form.get('managementNetworkIp').dirty || form.get('managementNetworkIp').touched)">
+          <label for="management-network-ip" aria-haspopup="true" role="tooltip" class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
+            [class.invalid]="form.get('managementNetworkIp').invalid && (form.get('managementNetworkIp').dirty || form.get('managementNetworkIp').touched)">
 
-            <input class="form-control"
-                   id="management-network-ip"
-                   type="text"
-                   placeholder="CIDR"
-                   formControlName="managementNetworkIp">
+            <input class="form-control" id="management-network-ip" type="text" placeholder="CIDR" formControlName="managementNetworkIp">
 
             <span class="tooltip-content" *ngIf="form.get('managementNetworkIp').hasError('required')">
               Management network CIDR cannot be empty
@@ -430,74 +350,33 @@
           </label>
 
         </div>
-        <div class="col-xs-1"></div>
       </div>
-
-      <div class="row form-group mb-0" *ngIf="form.get('managementNetwork').value">
-        <div class="col-xs offset-xs-6 text-right">
-
-          <label for="management-network-gateway">
-            Gateway
+      <div class="row form-group" *ngIf="form.get('managementNetwork').value">
+        <div class="col-xs-4 text-right">
+          <label for="management-network-routing">
+            Routing destination:Gateway
           </label>
-
         </div>
-        <div class="col-xs">
-
-          <label for="management-network-gateway"
-                 aria-haspopup="true"
-                 role="tooltip"
-                 class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
-                 [class.invalid]="form.get('managementNetworkGateway').invalid && (form.get('managementNetworkGateway').dirty || form.get('managementNetworkGateway').touched)">
-
-            <input class="form-control"
-                   id="management-network-gateway"
-                   type="text"
-                   placeholder="IP address"
-                   formControlName="managementNetworkGateway">
-
+        <div class="col-xs-8 col-xs routing-conf">
+          <label for="management-network-routing" aria-haspopup="true" role="tooltip" class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
+            [class.invalid]="form.get('managementNetworkRouting').invalid && (form.get('managementNetworkRouting').dirty || form.get('managementNetworkRouting').touched)">
+            <input class="form-control" id="management-network-routing" type="text" placeholder="Comma delimited CIDRs" formControlName="managementNetworkRouting">
+            <span class="tooltip-content" *ngIf="form.get('managementNetworkRouting').hasError('pattern')">
+              IP addresses are not valid, please input one or more routing destinations in a comma separated list, e.g. 10.1.0.0/16,10.2.0.0
+            </span>
+          </label>
+          <span>:</span>
+          <label for="management-network-gateway" aria-haspopup="true" role="tooltip" class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
+            [class.invalid]="form.get('managementNetworkGateway').invalid && (form.get('managementNetworkGateway').dirty || form.get('managementNetworkGateway').touched)">
+            <input class="form-control" id="management-network-gateway" type="text" placeholder="IP address" formControlName="managementNetworkGateway">
             <span class="tooltip-content" *ngIf="form.get('managementNetworkGateway').hasError('required')">
               Management network gateway cannot be empty
             </span>
-
             <span class="tooltip-content" *ngIf="form.get('managementNetworkGateway').hasError('pattern')">
-              Gateway address is not valid
+              Gateway address is not valid, please input ip address with format *.*.*.*. e.g. 10.1.119.23
             </span>
-
           </label>
-
         </div>
-        <div class="col-xs-1"></div>
-      </div>
-      <div class="row form-group" *ngIf="form.get('managementNetwork').value">
-        <div class="col-xs-3 text-right">
-
-          <label for="management-network-routing">
-            Routing destination
-          </label>
-
-        </div>
-        <div class="col-xs">
-
-          <label for="management-network-routing"
-                 aria-haspopup="true"
-                 role="tooltip"
-                 class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
-                 [class.invalid]="form.get('managementNetworkRouting').invalid && (form.get('managementNetworkRouting').dirty || form.get('managementNetworkRouting').touched)">
-
-            <input class="form-control"
-                   id="management-network-routing"
-                   type="text"
-                   placeholder="Comma delimited CIDRs"
-                   formControlName="managementNetworkRouting">
-
-            <span class="tooltip-content" *ngIf="form.get('managementNetworkRouting').hasError('pattern')">
-              IP addresses are not valid
-            </span>
-
-          </label>
-
-        </div>
-        <div class="col-xs-1"></div>
       </div>
 
       <div class="form-group row mb-0">
@@ -510,11 +389,7 @@
         </div>
         <div class="col-xs-3">
 
-          <input id="http-proxy-selector"
-                 class="form-control"
-                 formControlName="httpProxy"
-                 placeholder="IP or FQDN"
-                 type="text">
+          <input id="http-proxy-selector" class="form-control" formControlName="httpProxy" placeholder="IP or FQDN" type="text">
 
         </div>
 
@@ -524,16 +399,10 @@
 
 
 
-          <label for="http-proxy-port-selector"
-                 aria-haspopup="true"
-                 role="tooltip"
-                 class="tooltip tooltip-validation tooltip-md tooltip-top-left"
-                 [class.invalid]="form.get('httpProxyPort').invalid && (form.get('httpProxyPort').dirty || form.get('httpProxyPort').touched)">
+          <label for="http-proxy-port-selector" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-top-left"
+            [class.invalid]="form.get('httpProxyPort').invalid && (form.get('httpProxyPort').dirty || form.get('httpProxyPort').touched)">
 
-            <input id="http-proxy-port-selector"
-                   formControlName="httpProxyPort"
-                   placeholder="Port"
-                   type="text">
+            <input id="http-proxy-port-selector" formControlName="httpProxyPort" placeholder="Port" type="text">
 
             <span class="tooltip-content" *ngIf="form.get('httpProxyPort').hasError('maxlength')">
               Port cannot be more than 5 digits long
@@ -560,11 +429,7 @@
         </div>
         <div class="col-xs-3">
 
-          <input id="https-proxy-selector"
-                 class="form-control"
-                 placeholder="IP or FQDN"
-                 type="text"
-                 formControlName="httpsProxy">
+          <input id="https-proxy-selector" class="form-control" placeholder="IP or FQDN" type="text" formControlName="httpsProxy">
 
           <small class="text-muted text-nowrap">
             Note: This proxy settings are used only when pulling images, and not for any other purpose.
@@ -574,16 +439,10 @@
         <span class="mx-0 px-0">:</span>
         <div class="col-xs-1">
 
-          <label for="https-proxy-port-selector"
-                 aria-haspopup="true"
-                 role="tooltip"
-                 class="tooltip tooltip-validation tooltip-md tooltip-top-left"
-                 [class.invalid]="form.get('httpsProxyPort').invalid && (form.get('httpsProxyPort').dirty || form.get('httpsProxyPort').touched)">
+          <label for="https-proxy-port-selector" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-top-left"
+            [class.invalid]="form.get('httpsProxyPort').invalid && (form.get('httpsProxyPort').dirty || form.get('httpsProxyPort').touched)">
 
-            <input id="https-proxy-port-selector"
-                   placeholder="Port"
-                   type="text"
-                   formControlName="httpsProxyPort">
+            <input id="https-proxy-port-selector" placeholder="Port" type="text" formControlName="httpsProxyPort">
 
             <span class="tooltip-content" *ngIf="form.get('httpsProxyPort').hasError('maxlength')">
               Port cannot be more than 5 digits long
@@ -606,19 +465,17 @@
 
       <label>Optional Container Networks</label>
 
-      <div class="mb-2"
-           formArrayName="containerNetworks"
-           *ngFor="let containerNetwork of form.get('containerNetworks').controls; let i=index">
+      <div class="mb-2" formArrayName="containerNetworks" *ngFor="let containerNetwork of form.get('containerNetworks').controls; let i=index">
 
         <div class="form-group row mb-0" [formGroupName]="i">
-          <div class="col-xs">
+          <div class="col-xs-3">
 
             <label for="container-network-selector">
               Container network
             </label>
 
           </div>
-          <div class="col-xs">
+          <div class="col-xs-3">
 
             <div class="select form-control">
               <select id="container-network-selector" formControlName="containerNetwork">
@@ -630,59 +487,37 @@
             </div>
 
           </div>
-          <div class="col-xs text-right">
+          <div class="col-xs-3 text-right">
 
             <div class="radio-inline">
-              <input type="radio"
-                     value="dhcp"
-                     formControlName="containerNetworkType"
-                     [id]="'cont-dhcp-' + i">
+              <input type="radio" value="dhcp" formControlName="containerNetworkType" [id]="'cont-dhcp-' + i">
               <label [for]="'cont-dhcp-' + i">DHCP</label>
             </div>
 
             <div class="radio-inline">
-              <input type="radio"
-                     value="static"
-                     formControlName="containerNetworkType"
-                     [id]="'cont-static-' + i">
+              <input type="radio" value="static" formControlName="containerNetworkType" [id]="'cont-static-' + i">
               <label [for]="'cont-static-' + i">IP Range</label>
             </div>
 
           </div>
           <div class="col-xs">
 
-            <label for="container-network-ip-range"
-                   aria-haspopup="true"
-                   role="tooltip"
-                   class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
-                   [class.invalid]="form.get('containerNetworks').controls[i].controls.containerNetworkIpRange.invalid && (form.get('containerNetworks').controls[i].controls.containerNetworkIpRange.dirty || form.get('containerNetworks').controls[i].controls.containerNetworkIpRange.touched)">
+            <label for="container-network-ip-range" aria-haspopup="true" role="tooltip" class="form-control tooltip tooltip-validation tooltip-md tooltip-top-left"
+              [class.invalid]="form.get('containerNetworks').controls[i].controls.containerNetworkIpRange.invalid && (form.get('containerNetworks').controls[i].controls.containerNetworkIpRange.dirty || form.get('containerNetworks').controls[i].controls.containerNetworkIpRange.touched)">
 
-              <input class="form-control"
-                     id="container-network-ip-range"
-                     type="text"
-                     placeholder="IP range or CIDR"
-                     formControlName="containerNetworkIpRange">
+              <input class="form-control" id="container-network-ip-range" type="text" placeholder="IP range or CIDR" formControlName="containerNetworkIpRange">
 
               <span class="tooltip-content" *ngIf="form.get('containerNetworks').controls[i].controls.containerNetworkIpRange.hasError('required')">
                 Container network IP range cannot be empty
               </span>
 
             </label>
-
           </div>
-          <div class="col-xs-1 px-0 container-network-actions">
-
-            <clr-icon class="is-solid"
-                      shape="times-circle"
-                      (click)="removeContainerNetworkEntry(i)"
-                      *ngIf="i > 0">
+          <div class="container-network-actions">
+            <clr-icon class="is-solid" shape="times-circle" (click)="removeContainerNetworkEntry(i)" *ngIf="i > 0">
             </clr-icon>
-            <clr-icon class="is-solid"
-                      shape="plus-circle"
-                      (click)="addNewContainerNetworkEntry()"
-                      *ngIf="i === form.controls.containerNetworks.controls.length - 1">
+            <clr-icon class="is-solid" shape="plus-circle" (click)="addNewContainerNetworkEntry()" *ngIf="i === form.controls.containerNetworks.controls.length - 1">
             </clr-icon>
-
           </div>
         </div>
 
@@ -696,17 +531,10 @@
           </div>
           <div class="col-xs">
 
-            <label for="container-network-dns"
-                   aria-haspopup="true"
-                   role="tooltip"
-                   class="tooltip tooltip-validation tooltip-md tooltip-top-right"
-                   [class.invalid]="form.get('containerNetworks').controls[i].controls.containerNetworkDns.invalid && (form.get('containerNetworks').controls[i].controls.containerNetworkDns.dirty || form.get('containerNetworks').controls[i].controls.containerNetworkDns.touched)">
+            <label for="container-network-dns" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-top-right"
+              [class.invalid]="form.get('containerNetworks').controls[i].controls.containerNetworkDns.invalid && (form.get('containerNetworks').controls[i].controls.containerNetworkDns.dirty || form.get('containerNetworks').controls[i].controls.containerNetworkDns.touched)">
 
-              <input class="form-control"
-                     id="container-network-dns"
-                     type="text"
-                     placeholder="IP address"
-                     formControlName="containerNetworkDns">
+              <input class="form-control" id="container-network-dns" type="text" placeholder="IP address" formControlName="containerNetworkDns">
 
               <span class="tooltip-content" *ngIf="form.get('containerNetworks').controls[i].controls.containerNetworkDns.hasError('required')">
                 Container network DNS cannot be empty
@@ -728,17 +556,10 @@
           </div>
           <div class="col-xs">
 
-            <label for="container-network-gateway"
-                   aria-haspopup="true"
-                   role="tooltip"
-                   class="tooltip tooltip-validation tooltip-md tooltip-top-left"
-                   [class.invalid]="form.get('containerNetworks').controls[i].controls.containerNetworkGateway.invalid && (form.get('containerNetworks').controls[i].controls.containerNetworkGateway.dirty || form.get('containerNetworks').controls[i].controls.containerNetworkGateway.touched)">
+            <label for="container-network-gateway" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-top-left"
+              [class.invalid]="form.get('containerNetworks').controls[i].controls.containerNetworkGateway.invalid && (form.get('containerNetworks').controls[i].controls.containerNetworkGateway.dirty || form.get('containerNetworks').controls[i].controls.containerNetworkGateway.touched)">
 
-              <input class="form-control"
-                     id="container-network-gateway"
-                     type="text"
-                     placeholder="IP address"
-                     formControlName="containerNetworkGateway">
+              <input class="form-control" id="container-network-gateway" type="text" placeholder="IP address" formControlName="containerNetworkGateway">
 
               <span class="tooltip-content" *ngIf="form.get('containerNetworks').controls[i].controls.containerNetworkGateway.hasError('required')">
                 Container network gateway cannot be empty
@@ -751,30 +572,22 @@
             </label>
 
           </div>
-          <div class="col-xs-1"></div>
         </div>
 
         <div class="form-group row mb-0" [formGroupName]="i">
-          <div class="col-xs">
+          <div class="col-xs-3">
 
             <label for="container-network-label">
               Label
             </label>
 
           </div>
-          <div class="col-xs">
+          <div class="col-xs-3">
 
-            <label for="container-network-label"
-                   aria-haspopup="true"
-                   role="tooltip"
-                   class="form-control tooltip tooltip-validation tooltip-md tooltip-top-right"
-                   [class.invalid]="form.get('containerNetworks').controls[i].controls.containerNetworkLabel.invalid && (form.get('containerNetworks').controls[i].controls.containerNetworkLabel.dirty || form.get('containerNetworks').controls[i].controls.containerNetworkLabel.touched)">
+            <label for="container-network-label" aria-haspopup="true" role="tooltip" class="form-control tooltip tooltip-validation tooltip-md tooltip-top-right"
+              [class.invalid]="form.get('containerNetworks').controls[i].controls.containerNetworkLabel.invalid && (form.get('containerNetworks').controls[i].controls.containerNetworkLabel.dirty || form.get('containerNetworks').controls[i].controls.containerNetworkLabel.touched)">
 
-              <input class="form-control"
-                     id="container-network-label"
-                     type="text"
-                     placeholder="Network label"
-                     formControlName="containerNetworkLabel">
+              <input class="form-control" id="container-network-label" type="text" placeholder="Network label" formControlName="containerNetworkLabel">
 
               <span class="tooltip-content" *ngIf="form.get('containerNetworks').controls[i].controls.containerNetworkLabel.hasError('required')">
                 Container network label cannot be empty
@@ -785,22 +598,18 @@
               </span>
 
             </label>
-
           </div>
-          <!-- To set previous columns widths, we need to set space for 2 dynamic width column and 1 fixed width column -->
-          <div class="col-xs"></div>
-          <div class="col-xs offset-xs-1"></div>
         </div>
 
         <div class="form-group row mb-0" [formGroupName]="i">
-          <div class="col-xs">
+          <div class="col-xs-3">
 
             <label for="container-network-firewall">
               Firewall policy
             </label>
 
           </div>
-          <div class="col-xs">
+          <div class="col-xs-3">
 
             <div class="select form-control">
               <select id="container-network-firewall" formControlName="containerNetworkFirewall">
@@ -811,15 +620,9 @@
                 <option value="open">Open</option>
               </select>
             </div>
-
           </div>
-          <!-- To set previous columns widths, we need to set space for 2 dynamic width column and 1 fixed width column -->
-          <div class="col-xs"></div>
-          <div class="col-xs offset-xs-1"></div>
         </div>
-
       </div>
-
     </section>
   </form>
 </div>

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.scss
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.scss
@@ -18,3 +18,16 @@
 .bridge-network-signpost {
   width: 480px;
 }
+
+.routing-conf {
+  display: flex;
+}
+
+.absolute-info {
+  position: absolute;
+  right: 12px;
+}
+
+.relative-po {
+  position: relative !important;
+}


### PR DESCRIPTION

issue description:
When you provide a gateway for the management network, it's mandatory to provide at least one routing destination. UI Plugin doesn't reflect that. It has two separate fields for Gateway and Routing destinations. If the customer doesn't provide both the fields properly, plugin throws a weird parsing error [Refer to the screenshot].

Fix:
1 Modify UI to make routing destination required.
2 Modify the components destination input and ip address to one input.
Signed-off-by: Meina Zhou <meinaz@vmware.com>

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic-ui/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

PR acceptance checklist:

[ ] All unit tests pass
[ ] All e2e tests pass
[ ] Unit test(s) included*
[ ] e2e test(s) included*
[ ] Screenshot attached and UX approved*

 *if applicable, add n/a if not
