### PR TITLE
Cherry-pick: Publish artifacts from release branches separately (#582)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ pipeline:
       - 'make vic-ui-plugins'
     when:
       repo: vmware/vic-ui
-      branch: [master, 'releases/*']
+      branch: [master, develop, 'releases/*']
 
   bundle:
     image: 'gcr.io/eminent-nation-87317/vic-integration-test:1.36'
@@ -60,7 +60,7 @@ pipeline:
     when:
       repo: vmware/vic-ui
       event: [push, tag]
-      branch: [master, 'releases/*']
+      branch: [master, develop, 'releases/*']
 
   publish-gcs-builds-on-pass:
     image: 'victest/drone-gcs:1'
@@ -68,14 +68,46 @@ pipeline:
     secrets:
       - google_key
     source: bundle
-    target: vic-ui-builds
+    target: vic-ui-builds/
     acl:
       - 'allUsers:READER'
     cache_control: 'public,max-age=3600'
     when:
       repo: vmware/vic-ui
       event: [push]
-      branch: [master, 'releases/*']
+      branch: [master]
+      status: success
+
+  publish-gcs-develop-builds-on-pass:
+    image: 'victest/drone-gcs:1'
+    pull: true
+    secrets:
+      - google_key
+    source: bundle
+    target: vic-ui-builds/develop/
+    acl:
+      - 'allUsers:READER'
+    cache_control: 'public,max-age=3600'
+    when:
+      repo: vmware/vic-ui
+      event: [push]
+      branch: [develop]
+      status: success
+
+  publish-gcs-release-builds-on-pass:
+    image: 'victest/drone-gcs:1'
+    pull: true
+    secrets:
+      - google_key
+    source: bundle
+    target: vic-ui-builds/${DRONE_BRANCH}/
+    acl:
+      - 'allUsers:READER'
+    cache_control: 'public,max-age=3600'
+    when:
+      repo: vmware/vic-ui
+      event: [push]
+      branch: ['releases/*']
       status: success
 
   publish-gcs-releases:
@@ -99,6 +131,36 @@ pipeline:
       - codecov_token
     files:
       - 'h5c/vic/src/vic-webapp/coverage/lcov.info'
+
+  trigger-downstream:
+    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.3'
+    environment:
+      SHELL: /bin/bash
+      DOWNSTREAM_REPO: vmware/vic
+      DOWNSTREAM_BRANCH: ${DRONE_BRANCH}
+    secrets:
+      - drone_server
+      - drone_token
+    when:
+      repo: vmware/vic-ui
+      event: [push]
+      branch: [master]
+      status: success
+
+  trigger-downstream-tag:
+    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.3'
+    environment:
+      SHELL: /bin/bash
+      DOWNSTREAM_REPO: vmware/vic
+      DOWNSTREAM_BRANCH: ${DRONE_BRANCH}
+    secrets:
+      - drone_server
+      - drone_token
+    when:
+      repo: vmware/vic-ui
+      event: [tag]
+      branch: [master, 'releases/*']
+      status: success
 
   pass-rate:
     image: 'gcr.io/eminent-nation-87317/vic-integration-test:1.42'


### PR DESCRIPTION
Builds from all branches are written to the same directory,
so it is difficult to select the right build from corresponding
branches for downstream projects. Publish builds from
release branches to the same name sub-directories in the
bucket.

(cherry picked from commit 026d0f9bb412dbbaba8125af88d24b7a4dfe64c6)

Fixes #

PR acceptance checklist:

[ ] All unit tests pass
[ ] All e2e tests pass
[ ] Unit test(s) included*
[ ] e2e test(s) included*
[ ] Screenshot attached and UX approved*

 *if applicable, add n/a if not
