### PR TITLE
Enable tag event to make build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -37,9 +37,6 @@ pipeline:
     commands:
       - 'export BUILD_NUMBER=${DRONE_BUILD_NUMBER}'
       - 'make vic-ui-plugins'
-    when:
-      repo: vmware/vic-ui
-      branch: [master, develop, 'releases/*']
 
   bundle:
     image: 'gcr.io/eminent-nation-87317/vic-integration-test:1.36'
@@ -151,7 +148,7 @@ pipeline:
     image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.3'
     environment:
       SHELL: /bin/bash
-      DOWNSTREAM_REPO: vmware/vic
+      DOWNSTREAM_REPO: vmware/vic-product
       DOWNSTREAM_BRANCH: ${DRONE_BRANCH}
     secrets:
       - drone_server


### PR DESCRIPTION
Enable make vic-ui-plugins in any conditions include tag.
Trigger downstream repo vic-product to make build for
tag event.

Fixes #

PR acceptance checklist:

[ ] All unit tests pass
[ ] All e2e tests pass
[ ] Unit test(s) included*
[ ] e2e test(s) included*
[ ] Screenshot attached and UX approved*

 *if applicable, add n/a if not
