### PR TITLE
Fix errors when tag a build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -37,6 +37,8 @@ pipeline:
     commands:
       - 'export BUILD_NUMBER=${DRONE_BUILD_NUMBER}'
       - 'make vic-ui-plugins'
+    when:
+      status: success
 
   bundle:
     image: 'gcr.io/eminent-nation-87317/vic-integration-test:1.36'
@@ -56,8 +58,7 @@ pipeline:
       - 'ls -la bundle'
     when:
       repo: vmware/vic-ui
-      event: [push, tag]
-      branch: [master, develop, 'releases/*']
+      status: success
 
   publish-gcs-builds-on-pass:
     image: 'victest/drone-gcs:1'

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 REV :=$(shell git rev-parse --short=8 HEAD)
-TAG :=$(shell git for-each-ref --format="%(refname:short)" --sort=-authordate --count=1 refs/tags) # e.g. `v0.9.0`
-TAG_NUM :=$(shell git for-each-ref --format="%(refname:short)" --sort=-authordate --count=1 refs/tags | cut -c 2-) # e.g. `0.9.0`
+TAG :=$(shell git describe --tags --abbrev=0) # e.g. `v0.9.0`
+TAG_NUM :=$(shell git describe --tags --abbrev=0 | cut -c 2-) # e.g. `0.9.0`
 
 BIN ?= bin
 


### PR DESCRIPTION
Git for-each-ref returns wrong tag name, use git describe to
get latest tag.
Remove branch and event conditions since branch is empty if
it is a tag event. Execute vic-ui and bundle when status is
success.

Fixes #

PR acceptance checklist:

[ ] All unit tests pass
[ ] All e2e tests pass
[ ] Unit test(s) included*
[ ] e2e test(s) included*
[ ] Screenshot attached and UX approved*

 *if applicable, add n/a if not
