### PR TITLE
Add vic appliance ip information in vic plugin summary view. 

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.service.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.service.spec.ts
@@ -205,19 +205,17 @@ describe('CreateVchWizardService', () => {
         expect(response).toBe('10.20.250.255');
       });
 
-      connection.mockRespond(new Response(new ResponseOptions({
-        body: ['vic-ova-2: v1.2.0-12000-bbbbbb, 10.20.250.255', 'vic-ova-1: v1.1.0-11000-aaaaaa, 10.20.250.254']
-      })));
+      if (!connection.response) {
+        connection.mockRespond(new Response(new ResponseOptions({
+          body: ['vic-ova-2: v1.2.0-12000-bbbbbb, 10.20.250.255', 'vic-ova-1: v1.1.0-11000-aaaaaa, 10.20.250.254']
+        })));
+      }
     });
 
-    it('should handle invalid response from VIC appliance lookup endpoint', async() => {
-      service.getVicApplianceIp().subscribe(response => {}, err => {
-        expect(err).toBeTruthy();
+    it('should get value from cache if invoke ip address api second time', async() => {
+      service.getVicApplianceIp().subscribe(response => {
+        expect(response).toBe('10.20.250.255');
       });
-
-      connection.mockRespond(new Response(new ResponseOptions({
-        body: 'not an array of string values'
-      })));
     });
 
     it('should retrieve a list of distributed port groups', async() => {

--- a/h5c/vic/src/vic-webapp/src/app/summary-view/summary-view.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/summary-view/summary-view.component.html
@@ -7,34 +7,58 @@
       </div>
     </div>
   </div>
-  <div class="col-xs-12">
+  <div class="col-xs-12 summary-wrapper">
     <img class="vic-summary-view-logo" src="{{ vicLogoPath }}">
-    <ul class="summary-items-list">
-      <li id="vendor">
-        <span class="summary-label">
-          {{ vicI18n.translate(WS_SUMMARY_CONSTANTS, 'VENDOR') }}
-        </span>
-        <span class="summary-value">
-          VMware
-        </span>
-      </li>
-      <li id="version">
-        <span class="summary-label">
-          {{ vicI18n.translate(WS_SUMMARY_CONSTANTS, 'VERSION') }}
-        </span>
-        <span class="summary-value">
-          {{ pluginVersion }}
-        </span>
-      </li>
-      <li id="vch_len">
-        <span class="summary-label">
-          {{ vicI18n.translate(WS_SUMMARY_CONSTANTS, 'VCH') }}
-        </span>
-        <span class="summary-value">
-          {{ vchVmsLen }}
-        </span>
-      </li>
-    </ul>
+    <section class="summary-content">
+      <div class="summary-title">VIC PLUGIN INFORMATION</div>
+      <ul class="summary-items-list">
+        <li id="vendor">
+          <span class="summary-label">
+            {{ vicI18n.translate(WS_SUMMARY_CONSTANTS, 'VENDOR') }}
+          </span>
+          <span class="summary-value">
+            VMware
+          </span>
+        </li>
+        <li id="version">
+          <span class="summary-label">
+            {{ vicI18n.translate(WS_SUMMARY_CONSTANTS, 'VERSION') }}
+          </span>
+          <span class="summary-value">
+            {{ pluginVersion }}
+          </span>
+        </li>
+        <li id="vch_len">
+          <span class="summary-label">
+            {{ vicI18n.translate(WS_SUMMARY_CONSTANTS, 'VCH') }}
+          </span>
+          <span class="summary-value">
+            {{ vchVmsLen }}
+          </span>
+        </li>
+      </ul>
+    </section>
+    <section class="summary-content">
+      <div class="summary-title">VIC APPLIANCE INFORMATION</div>
+      <ul class="summary-items-list">
+          <li>
+              <span class="summary-label">
+                  {{ vicI18n.translate(WS_SUMMARY_CONSTANTS, 'VERSION') }}
+              </span>
+              <span class="summary-value">  
+                  {{applianceVersion}}
+              </span>
+           </li>
+          <li>
+             <span class="summary-label">
+                   IP Address
+             </span>
+             <span class="summary-value">
+                  {{applianceIp}}
+             </span>
+          </li>
+        </ul>
+    </section>
   </div>
   <div class="col-xs">
     <p class="summary-intro mt-3">

--- a/h5c/vic/src/vic-webapp/src/app/summary-view/summary-view.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/summary-view/summary-view.component.spec.ts
@@ -69,6 +69,9 @@ describe('VIC object view: Summary tab', () => {
                 { provide: CreateVchWizardService, useValue: {
                   verifyVicMachineApiEndpoint() {
                     return Observable.of('10.10.10.10');
+                  },
+                  getAppliance() {
+                      return Observable.of(['vic-ova-2: v1.2.0-12000-bbbbbb, 10.20.250.255']);
                   }
                 }}
             ],

--- a/h5c/vic/src/vic-webapp/src/app/summary-view/summary-view.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/summary-view/summary-view.component.ts
@@ -24,7 +24,7 @@ import {
 import { CreateVchWizardService } from '../create-vch-wizard/create-vch-wizard.service';
 import { DataPropertyService } from '../services/data-property.service';
 import { Observable } from 'rxjs/Observable';
-import { Subscription } from 'rxjs/Rx';
+import { Subscription, Subject} from 'rxjs/Rx';
 import { Vic18nService } from '../shared/vic-i18n.service';
 
 @Component({
@@ -37,10 +37,13 @@ export class VicSummaryViewComponent implements OnInit, OnDestroy {
     public vicLogoPath: string;
     public pluginVersion: string;
     public vchVmsLen: number;
+    public appliance = new Subject<string []>();
     public readonly WS_SUMMARY_CONSTANTS = WS_SUMMARY;
     private rootInfoSubscription: Subscription;
     private refreshSubscription: Subscription;
     public error: any;
+    public applianceIp: string;
+    public applianceVersion: string;
 
     constructor(
         private zone: NgZone,
@@ -87,9 +90,22 @@ export class VicSummaryViewComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.fetchRootInfo();
-
         // verify the appliance endpoint
+        this.getApplianceInfo();
         this.checkVicMachineServer();
+    }
+
+    getApplianceInfo() {
+        this.createWzService.getAppliance()
+        .subscribe(
+            (response) => {
+              if (response.length > 0) {
+                const splitByColon = response[0].split(':');
+                this.applianceVersion = splitByColon[0];
+                this.applianceIp = splitByColon[1].split(',')[1].trim();
+              }
+            }
+        )
     }
 
     checkVicMachineServer() {

--- a/h5c/vic/src/vic-webapp/src/app/summary-view/vic-summary-view.scss
+++ b/h5c/vic/src/vic-webapp/src/app/summary-view/vic-summary-view.scss
@@ -18,6 +18,7 @@ div.summary-container {
   padding-top: 10px;
   font-size: 13px;
   img.vic-summary-view-logo {
+    height:100px;
     padding-right: 2em;
     vertical-align: top;
   }
@@ -29,7 +30,7 @@ ul.summary-items-list {
     display: table-row-group;
     span.summary-label {
       display: table-cell;
-      width: auto;
+      min-width: 145px;
     }
     span.summary-value {
       display: table-cell;
@@ -47,4 +48,18 @@ p.summary-intro {
 
 .mb-2 {
   margin-bottom: 2rem !important;
+}
+
+.summary-wrapper {
+  display: flex;
+
+  .summary-content {
+    margin-right: 80px;
+    min-width:340px;
+  }
+
+  .summary-title {
+    font-weight: bold;
+    margin-bottom: 10px;
+  }
 }


### PR DESCRIPTION
As the user is not able to select which API server to use (#572), providing this information may greatly aid debugging when multiple versions of API servers are available.
Fix:
1 Add vic appliance version information in summary view. 
2 Add vic appliance ip address in summary view. 