### PR TITLE
Cherry-Pick: Fix missing branch for tag event (#597)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -120,6 +120,7 @@ pipeline:
     cache_control: 'public,max-age=3600'
     when:
       repo: vmware/vic-ui
+      branch: ['releases/*', 'refs/tags/*']
       event: tag
       status: success
 
@@ -141,23 +142,8 @@ pipeline:
       - drone_token
     when:
       repo: vmware/vic-ui
-      event: [push]
-      branch: [master]
-      status: success
-
-  trigger-downstream-tag:
-    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.3'
-    environment:
-      SHELL: /bin/bash
-      DOWNSTREAM_REPO: vmware/vic-product
-      DOWNSTREAM_BRANCH: ${DRONE_BRANCH}
-    secrets:
-      - drone_server
-      - drone_token
-    when:
-      repo: vmware/vic-ui
-      event: [tag]
-      branch: [master, 'releases/*']
+      event: [push, tag]
+      branch: [master, 'releases/*', 'refs/tags/*']
       status: success
 
   pass-rate:


### PR DESCRIPTION
Adding tag from git command is different from tagging from
github web, the branch is refs/tags/* instead of releases/*
. Add refs/tags/* to branch so tag from git command can
also publish builds and trigger downstream project.

(cherry picked from commit c36a2f85b73f4bca1529ec18d3fbbfd787d76158)

Fixes #

PR acceptance checklist:

[ ] All unit tests pass
[ ] All e2e tests pass
[ ] Unit test(s) included*
[ ] e2e test(s) included*
[ ] Screenshot attached and UX approved*

 *if applicable, add n/a if not
