### PR TITLE
fix datacenter can not show host

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.service.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.service.ts
@@ -232,8 +232,18 @@ export class CreateVchWizardService {
      */
     getDcClustersAndStandAloneHosts(dcObj: ComputeResource): Observable<ComputeResource[]> {
       const props = 'host,cluster';
-      return this.getResourceProperties<{host: ResourceBasicInfo[]; cluster: ResourceBasicInfo[]}>(dcObj.objRef, props)
-        .map(data => ({childResources: data['cluster'].concat(data['host'])}))
+      return this.getResourceProperties<{ host: ResourceBasicInfo[]; cluster: ResourceBasicInfo[] }>(dcObj.objRef, props)
+        .map(data => {
+          if (data['cluster']) {
+            return {
+              childResources: data['cluster'].concat(data['host'])
+            }
+          } else {
+            return {
+              childResources: data['host']
+            }
+          }
+        })
         .switchMap(basicData => {
           return this.getResourcesCompleteInfo(basicData.childResources)
             .switchMap((completeData: ComputeResource[]) => {


### PR DESCRIPTION
If datacenter only contains host without cluster, host can not show in VCH create wizard. 
That is because a javascript error. 
Need to deal with the case datacenter does not contain cluster. 