### PR TITLE
Update GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect.md
+++ b/.github/ISSUE_TEMPLATE/defect.md
@@ -1,0 +1,74 @@
+---
+name: "Defect Report"
+about: Report something that isn't working as expected
+
+---
+
+<!--
+This repository is for the VIC vSphere Client Plugins. Please use it to report issues related to those user interfaces.
+
+To help use keep things organized, please file issues in the most appropriate repository:
+ * VIC Engine (VCHs, Container VMs, and their lifecycles): https://github.com/vmware/vic/issues
+ * VIC Appliance (OVA) and User Documentation: https://github.com/vmware/vic-product/issues
+ * Container Management Portal (Admiral): https://github.com/vmware/admiral/issues
+ * Container Registry (Harbor): https://github.com/goharbor/harbor/issues
+-->
+
+#### Summary
+<!-- Explain the problem briefly. -->
+
+
+#### Environment information
+<!-- Describe the environment where the issue occurred. -->
+
+##### vSphere and vCenter Server version
+<!-- Indicate the vSphere and vCenter Server version(s) being used. -->
+
+##### VIC UI version
+<!-- Indicate the VIC UI version being used (found on the Summary tab). -->
+
+##### VIC Appliance version
+<!-- Indicate the full filename of the VIC Appliance version that you deployed (e.g., vic-vX.Y.Z-tag-NNNN-abcdef0.ova). -->
+
+##### Platform details
+<!-- Which platform are you using? (Windows, Mac OS, Linux, etc) -->
+
+##### Browser details
+<!-- Which browser are you using? (Chrome, Firefox, Internet Explorer, etc) -->
+
+
+#### Details
+<!-- Provide additional details. -->
+
+##### Steps to reproduce
+
+##### Actual behavior
+
+##### Expected behavior
+
+##### Request/response
+<!-- If you are comfortable doing so, please capture the relevant request/response, including headers, from the browser's developer tools. -->
+
+
+#### Logs
+<!--
+Please attach the vsphere_client_virgo.log
+  https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.monitoring.doc/GUID-7E10C58F-16EA-44AB-8AA0-8D4A66399879.html
+-->
+
+
+#### See also
+<!-- Provide references to relevant resources, such as documentation or related issues. -->
+
+
+#### Troubleshooting attempted
+<!-- Use this section to indicate steps you've already taken to troubleshoot the issue. -->
+
+- [ ] Searched [GitHub][issues] for existing issues. (Mention any similar issues under "See also", above.)
+- [ ] Searched the [documentation][docs] for relevant troubleshooting guidance.
+- [ ] Searched for a relevant [VMware KB article][kb].
+
+<!-- Reference-style links used above; removing these will break the links. -->
+[issues]:https://github.com/vmware/vic-ui/issues
+[docs]:https://vmware.github.io/vic-product/#documentation
+[kb]:https://kb.vmware.com/s/global-search/%40uri#t=Knowledge&sort=relevancy&f:@commonproduct=[vSphere%20Integrated%20Containers]

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,40 @@
+---
+name: "Feature/Enhancement Request"
+about: Request an new feature or enhancement to existing functionality 
+
+---
+
+<!--
+This repository is for the VIC vSphere Client Plugins. Please use it to report issues related to those user interfaces.
+
+To help use keep things organized, please file issues in the most appropriate repository:
+ * VIC Engine (VCHs, Container VMs, and their lifecycles): https://github.com/vmware/vic/issues
+ * VIC Appliance (OVA) and User Documentation: https://github.com/vmware/vic-product/issues
+ * Container Management Portal (Admiral): https://github.com/vmware/admiral/issues
+ * Container Registry (Harbor): https://github.com/goharbor/harbor/issues
+-->
+
+#### Summary
+<!-- Explain the request briefly. -->
+
+
+#### User statement(s)
+<!--
+Brief statement(s) that describe who, what and why. These help the engineer addressing the request better understand the user's point of view.
+
+Optionally, include a nested list of conditions of satisfaction for each statement. These may be added later, shortly before work begins on a request.
+
+Example (from https://www.mountaingoatsoftware.com/agile/user-stories):
+ * As a vice president of marketing, I want to select a holiday season to be used when reviewing the performance of past advertising campaigns so that I can identify profitable ones.
+    * Support holidays that span two calendar years (none span three).
+    * Holiday seasons can be set from one holiday to the next (such as Thanksgiving to Christmas).
+    * Holiday seasons can be set to be a number of days prior to the holiday.
+-->
+
+
+#### Details
+<!-- Provide any additional details that do not fit the above format. -->
+
+
+#### See also
+<!-- Provide references to relevant resources, such as documentation or related issues. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,3 +1,9 @@
+---
+name: "Question"
+about: Ask a question about the product
+
+---
+
 <!--
 This repository is for the VIC vSphere Client Plugins. Please use it to report issues related to those user interfaces.
 
@@ -8,13 +14,15 @@ To help use keep things organized, please file issues in the most appropriate re
  * Container Registry (Harbor): https://github.com/goharbor/harbor/issues
 -->
 
-#### Summary
-<!-- Explain the issue briefly. -->
+<!--
+NOTE: Our public Slack channel is often a better way to ask questions and get answers. Consider trying that first, before opening a GitHub issue.
+
+See https://github.com/vmware/vic/blob/master/CONTRIBUTING.md#community for details.
+-->
+
+#### Question
+<!-- Explain the question briefly. -->
 
 
-#### Details
-<!-- Provide additional details. -->
-
-
-#### See Also
+#### See also
 <!-- Provide references to relevant resources, such as documentation or related issues. -->

--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -1,0 +1,16 @@
+---
+name: "Security Issue"
+about: Product issues with security impact
+
+---
+
+> VMware encourages users who become aware of a security vulnerability in VMware products to contact VMware with details of the vulnerability. VMware has established an email address that should be used for reporting a vulnerability. Please send descriptions of any vulnerabilities found to security@vmware.com. Please include details on the software and hardware configuration of your system so that we can duplicate the issue being reported.
+> 
+> **Note:** We encourage use of encrypted email. Our public PGP key is found at https://kb.vmware.com/kb/1055.
+> 
+> VMware hopes that users encountering a new vulnerability will contact us privately as it is in the best interests of our customers that VMware has an opportunity to investigate and confirm a suspected vulnerability before it becomes public knowledge.
+> 
+> In the case of vulnerabilities found in third-party software components used in VMware products, please also notify VMware as described above.
+
+For more information, see https://www.vmware.com/support/policies/security_response.html
+

--- a/.github/ISSUE_TEMPLATE/test-failure.md
+++ b/.github/ISSUE_TEMPLATE/test-failure.md
@@ -1,3 +1,9 @@
+---
+name: "Test Failure"
+about: Report failure of an automated test
+
+---
+
 <!--
 This repository is for the VIC vSphere Client Plugins. Please use it to report issues related to those user interfaces.
 
@@ -8,13 +14,21 @@ To help use keep things organized, please file issues in the most appropriate re
  * Container Registry (Harbor): https://github.com/goharbor/harbor/issues
 -->
 
-#### Summary
-<!-- Explain the issue briefly. -->
+#### Symptom
+<!-- The error message, failure mode, or pattern that indicates this issue. -->
 
 
-#### Details
-<!-- Provide additional details. -->
+#### Test case(s)
+<!-- The test case(s) (including test, suite, and group information) exhibiting this symptom. -->
 
 
-#### See Also
+#### Robot output
+<!-- Any command-line output associated with the failure. -->
+
+
+#### Logs
+<!-- A list of failed jobs, with links to relevant logs (e.g., log.html). -->
+
+
+#### See also
 <!-- Provide references to relevant resources, such as documentation or related issues. -->


### PR DESCRIPTION
Introduce a set of issue templates for common types of issues, such as defects, feature requests, questions, and test failures. Additionally, introduce a issue template for security issues that directs users to VMware's official security response policy.

Revise default template to be more appropriate for more issues that do not fall into any of these categories (e.g., infrastructure issues and tasks).

---

Related: vmware/vic#8280, vmware/vic-product#2100
