### PR TITLE
use compute-resource in command string

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.component.ts
@@ -268,8 +268,7 @@ export class ComputeCapacityComponent implements OnInit {
       const cpuLimitValue = this.form.get('cpuLimit').value;
       const memoryLimitValue = this.form.get('memoryLimit').value;
 
-      results['computeResource'] = this.selectedId;
-      results['computeResourceName'] = this.selectedName;
+      results['computeResource'] = this.selectedName;
       results['cpu'] = unlimitedPattern.test(cpuLimitValue) ? '0' : cpuLimitValue;
       results['memory'] = unlimitedPattern.test(memoryLimitValue) ? '0' : memoryLimitValue;
       if (this.inAdvancedMode) {


### PR DESCRIPTION
Issue description:
Currently, vic ui use: **--compute-resource $resourceId --compute-resource-name $resourceName** in the summary command line. 

Modify it as: 
**--compute-resource $resourceName**  instead. 
