### PR TITLE
fix cluster and vcenter order

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-capacity.component.ts
@@ -27,7 +27,7 @@ import { GlobalsService } from './../../shared/globals.service';
 import { ComputeResource } from '../../interfaces/compute.resource';
 import { getMorIdFromObjRef, resourceIsCluster, resourceIsHost, resourceIsResourcePool } from '../../shared/utils/object-reference';
 import { ServerInfo } from '../../shared/vSphereClientSdkTypes';
-import { flattenArray } from '../../shared/utils/array-utils';
+import { flattenArray, compareFn } from '../../shared/utils/array-utils';
 import { I18nService } from '../../shared';
 
 const endpointMemoryDefaultValue = 2048;
@@ -119,7 +119,7 @@ export class ComputeCapacityComponent implements OnInit {
     const obsArr = this.serversInfo.map(serverInfo => this.createWzService.getDatacenter(serverInfo.serviceGuid));
     Observable.zip(...obsArr)
       .subscribe(results => {
-        this.datacenter = flattenArray(results);
+        this.datacenter = flattenArray(results).sort(compareFn);
       });
   }
 

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/compute-capacity/compute-resource-treenode.component.ts
@@ -29,6 +29,7 @@ import { CreateVchWizardService } from '../create-vch-wizard.service';
 import { GlobalsService } from '../../shared';
 import { ComputeResource } from '../../interfaces/compute.resource';
 import { ServerInfo } from '../../shared/vSphereClientSdkTypes';
+import { compareFn } from '../../shared/utils/array-utils';
 import { resourceIsCluster, resourceIsHost, resourceIsResourcePool } from '../../shared/utils/object-reference';
 import { Observable } from 'rxjs/Observable';
 
@@ -85,8 +86,12 @@ export class ComputeResourceTreenodeComponent implements OnInit {
         this.vicResourcePoolNamesList = data[1];
 
         const ClustersAndStandAloneHosts: ComputeResource[] = data[0];
-        this.clusters = ClustersAndStandAloneHosts.filter(v => resourceIsCluster(v.type));
-        this.standaloneHosts = ClustersAndStandAloneHosts.filter(v => resourceIsHost(v.type));
+        this.clusters = ClustersAndStandAloneHosts
+        .filter(v => resourceIsCluster(v.type))
+        .sort(compareFn);
+        this.standaloneHosts = ClustersAndStandAloneHosts
+        .filter(v => resourceIsHost(v.type))
+        .sort(compareFn);
 
         if (!this.clusters.length) {
           this.loading = false;
@@ -149,6 +154,4 @@ export class ComputeResourceTreenodeComponent implements OnInit {
 
     return allowedResourcePool || allowedCluster || allowedHost;
   }
-
-
-  }
+}

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.service.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.service.ts
@@ -196,11 +196,15 @@ export class CreateVchWizardService {
      * @returns {Observable<ComputeResource[]>}
      */
     getResourcesCompleteInfo(basicInfoList: ResourceBasicInfo[]): Observable<ComputeResource[]> {
-      const infoListObs: Observable<ComputeResource>[] = basicInfoList
+      if (basicInfoList) {
+        const infoListObs: Observable<ComputeResource>[] = basicInfoList
         .map(resourceBasicInfo => {
           return this.getResourceCompleteInfo(resourceBasicInfo)
-      });
-      return infoListObs.length > 0 ? Observable.zip(...infoListObs) : Observable.of([]);
+        });
+        return infoListObs.length > 0 ? Observable.zip(...infoListObs) : Observable.of([]);
+      } else {
+        return Observable.of([]);
+      }
     }
 
     /**

--- a/h5c/vic/src/vic-webapp/src/app/shared/utils/array-utils.ts
+++ b/h5c/vic/src/vic-webapp/src/app/shared/utils/array-utils.ts
@@ -19,3 +19,14 @@ export function flattenArray(list: Array<any>) {
     return a.concat(Array.isArray(b) ? flattenArray(b) : b);
   }, [])
 }
+
+export function compareFn(a: any, b: any) {
+  if (a.name < b.name) {
+    return -1;
+  }
+  if (a.name > b.name) {
+    return 1;
+  }
+  // names must be equal
+  return 0;
+}


### PR DESCRIPTION
in create vch wizard. In select "compute resource" view. 
The vcenter and clusters and hosts are not in correct order. That is because we get the data directly from vsphere sdk without sort them. 
fix:
In the ui view, add sort function to all those list to keep align with vcenter tree view. 