### PR TITLE
Document core maintainers for the repository

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,19 @@
+This file documents the current people responsible for maintaining this
+repository, and their roles. This provides context to help the broader community
+better understand who they are interacting with (e.g., when reading, creating,
+or commenting on issues and pull requests).
+
+This document is not intended to list all contributors, and many important and
+valued members of the extended team are not listed below.
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for general contribution
+guidelines and [Contributors](https://github.com/vmware/vic/graphs/contributors)
+for a more complete list of contributors.
+
+Core Maintainers
+================
+
+* Steven Ren ([@renmaosheng](https://github.com/renmaosheng)), Engineering Manager
+* James Zabala ([@clouderati](https://github.com/clouderati)), Product Manager
+* Mia Zhou ([zhoumeina](https://github.com/zhoumeina))
+


### PR DESCRIPTION
Documents the current people responsible for maintaining this repository, and their roles. This provides context to help the broader community better understand who they are interacting with.