### PR TITLE
modify registry doc url

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.html
@@ -126,7 +126,7 @@
 
     <ng-template clrPageTitle>
       Security
-      <a [href]="'https://vmware.github.io/vic-product/assets/files/html/' + pluginLinkVersion + '/vic_vsphere_admin/vch_security.html'"
+      <a [href]="'https://vmware.github.io/vic-product/assets/files/html/' + pluginLinkVersion + '/vic_vsphere_admin/vch_registry.html'"
          target="_blank">
         <clr-icon shape="help" class="is-info"></clr-icon>
       </a>


### PR DESCRIPTION
issue description: Before the regitry help document is link to https://vmware.github.io/vic-product/assets/files/html/1.5/vic_vsphere_admin/vch_security.html. It should open https://vmware.github.io/vic-product/assets/files/html/1.5/vic_vsphere_admin/vch_registry.html.