### PR TITLE
Enter required vSphere username to ignore spaces when deploying vch by GUI

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/operations-user/operations-user.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/operations-user/operations-user.component.ts
@@ -42,7 +42,7 @@ export class OperationsUserComponent implements OnInit {
   onCommit(): Observable<any> {
     const result = {
       'operations': {
-        opsUser: this.form.get('opsUser').value,
+        opsUser: this.form.get('opsUser').value.trim(),
         opsPassword: this.form.get('opsPassword').value,
       }
     };


### PR DESCRIPTION
fixed #2269
When creating VCH in vSphere client, at the last step, vSphere client user credential was needed, if blank space was attached by accident, there will be a failure of creating VCH.Therefore, use trim to remove spaces when getting the username entered.
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>