### PR TITLE
modify network links according to document

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.html
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.html
@@ -4,7 +4,7 @@
     Specify the networks used to access this virtual container host.
   </p>
 
-  <a class="btn btn-link pl-0" [href]="'https://vmware.github.io/vic-product/assets/files/html/' + pluginLinkVersion + '/vic_vsphere_admin/vch_networking.html'"
+  <a class="btn btn-link pl-0" [href]="'https://vmware.github.io/vic-product/assets/files/html/' + pluginLinkVersion + '/vic_vsphere_admin/network_reqs.html'"
     target="_blank">
     View Network Requirements
     <clr-icon shape="pop-out"></clr-icon>


### PR DESCRIPTION
Modify the network link according to documentation required. 
![image](https://user-images.githubusercontent.com/4946616/51006387-e6df4d00-157d-11e9-8636-8bc854265242.png)
change the VIEW NETWORK REQUIREMENTS button to point to the new page, https://vmware.github.io/vic-product/assets/files/html/1.5/vic_vsphere_admin/network_reqs.html? The general help button at the top can stay as it is.
