### PR TITLE
Fix management and client interfaces static IP assignments

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.ts
@@ -365,9 +365,7 @@ export class CreateVchWizardComponent implements OnInit {
       };
 
       if (payload.networks.clientNetworkIp) {
-        processedPayload.network['client']['static'] = {
-          ip: payload.networks.clientNetworkIp
-        };
+        processedPayload.network['client']['static'] = payload.networks.clientNetworkIp;
 
         processedPayload.network['client']['gateway'] = {
           address: payload.networks.clientNetworkGateway
@@ -391,9 +389,7 @@ export class CreateVchWizardComponent implements OnInit {
       };
 
       if (payload.networks.managementNetworkIp) {
-        processedPayload.network['management']['static'] = {
-          ip: payload.networks.managementNetworkIp
-        };
+        processedPayload.network['management']['static'] = payload.networks.managementNetworkIp;
 
         processedPayload.network['management']['gateway'] = {
           address: payload.networks.managementNetworkGateway


### PR DESCRIPTION
Fixes #220 
When using the plugin UI wizard to assign static IP to the management and client interfaces
The creation fails with this error:
> parsing vch body from "" failed, because json: cannot unmarshal object into Go struct field Network.static of type models.CIDR
The cause of this failure is in the way the UI constructs the request body. The static setting must be a string, not an object，so change the object of request body to a string
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>
