### PR TITLE
Change the gateway in the client network to optional on ui

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.spec.ts
@@ -135,7 +135,6 @@ describe('NetworksComponent', () => {
 
     // gateway fields are required
     expect(publicNetworkGateway.errors['required']).toBeTruthy();
-    expect(clientNetworkGateway.errors['required']).toBeTruthy();
     expect(managementNetworkGateway.errors['required']).toBeTruthy();
 
     // gateway fields to something incorrect

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.ts
@@ -70,7 +70,6 @@ export class NetworksComponent implements OnInit {
       ]],
       clientNetworkType: 'dhcp',
       clientNetworkGateway: [{ value: '', disabled: true }, [
-        Validators.required,
         Validators.pattern(ipPattern)
       ]],
       clientNetworkRouting: [{ value: '', disabled: true }, [


### PR DESCRIPTION
The gateway is optional when using the plugin UI wizard to assign static IP to the client interface.
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic-ui/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

PR acceptance checklist:

[ ] All unit tests pass
[ ] All e2e tests pass
[ ] Unit test(s) included*
[ ] e2e test(s) included*
[ ] Screenshot attached and UX approved*

 *if applicable, add n/a if not
