### PR TITLE
Fix cannot assigne Static IP to Management and Client interface using Plugin UI Wizard

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/create-vch-wizard.component.ts
@@ -360,18 +360,18 @@ export class CreateVchWizardComponent implements OnInit {
     if (payload.networks.clientNetwork) {
       processedPayload.network['client'] = {
         port_group: {
-          name: payload.networks.publicNetwork
+          name: payload.networks.clientNetwork
         }
       };
 
       if (payload.networks.clientNetworkIp) {
         processedPayload.network['client']['static'] = payload.networks.clientNetworkIp;
 
-        processedPayload.network['client']['gateway'] = {
-          address: payload.networks.clientNetworkGateway
-        };
-
-        if (payload.networks.clientNetworkRouting && payload.networks.clientNetworkRouting.length) {
+        if (payload.networks.clientNetworkGateway && payload.networks.clientNetworkRouting
+          && payload.networks.clientNetworkRouting.length) {
+          processedPayload.network['client']['gateway'] = {
+            address: payload.networks.clientNetworkGateway
+          };
           processedPayload.network['client']['gateway']['routing_destinations'] = payload.networks.clientNetworkRouting;
         }
 
@@ -391,11 +391,13 @@ export class CreateVchWizardComponent implements OnInit {
       if (payload.networks.managementNetworkIp) {
         processedPayload.network['management']['static'] = payload.networks.managementNetworkIp;
 
-        processedPayload.network['management']['gateway'] = {
-          address: payload.networks.managementNetworkGateway
-        };
 
-        if (payload.networks.managementNetworkRouting && payload.networks.managementNetworkRouting.length) {
+
+        if (payload.networks.managementNetworkGateway && payload.networks.managementNetworkRouting
+          && payload.networks.managementNetworkRouting.length) {
+          processedPayload.network['management']['gateway'] = {
+            address: payload.networks.managementNetworkGateway
+          };
           processedPayload.network['management']['gateway']['routing_destinations'] = payload.networks.managementNetworkRouting;
         }
 

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.spec.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.spec.ts
@@ -135,7 +135,6 @@ describe('NetworksComponent', () => {
 
     // gateway fields are required
     expect(publicNetworkGateway.errors['required']).toBeTruthy();
-    expect(managementNetworkGateway.errors['required']).toBeTruthy();
 
     // gateway fields to something incorrect
     publicNetworkGateway.setValue('invalidAddress');

--- a/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.ts
+++ b/h5c/vic/src/vic-webapp/src/app/create-vch-wizard/networks/networks.component.ts
@@ -82,7 +82,6 @@ export class NetworksComponent implements OnInit {
       ]],
       managementNetworkType: 'dhcp',
       managementNetworkGateway: [{ value: '', disabled: true }, [
-        Validators.required,
         Validators.pattern(ipPattern)
       ]],
       managementNetworkRouting: [{ value: '', disabled: true }, [


### PR DESCRIPTION
When the gateway is empty, the gateway object will not be transmitted when the request is sent.
Signed-off-by: Fangyuan Cheng fangyuanc@vmware.com

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic-ui/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

PR acceptance checklist:

[ ] All unit tests pass
[ ] All e2e tests pass
[ ] Unit test(s) included*
[ ] e2e test(s) included*
[ ] Screenshot attached and UX approved*

 *if applicable, add n/a if not
