### PR TITLE
support pkcs1 format private key in ui wizard

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/shared/utils/certificates.ts
+++ b/h5c/vic/src/vic-webapp/src/app/shared/utils/certificates.ts
@@ -64,13 +64,14 @@ export function parseCertificatePEMFileContent(str: string): CertificateInfo {
 }
 
 export function parsePrivateKeyPEMFileContent(str: string): PrivateKeyInfo {
-
   // Remove headers
+  if (str.indexOf('RSA PRIVATE KEY') !== -1) {
+    str = str.replace(/(-----(BEGIN|END) RSA PRIVATE KEY-----|\n)/g, '');
+    return { algorithm: 'RSA' };
+  }
   str = str.replace(/(-----(BEGIN|END) PRIVATE KEY-----|\n)/g, '');
-
   // Decode Base64 string, convert to an ArrayBuffer and parse raw data
   const asn1 = fromBER(stringToArrayBuffer(fromBase64(str)));
-
   // Create Private Key model
   const privateKey = new InternalPrivateKeyInfo({ schema: asn1.result });
 


### PR DESCRIPTION
the frontend will throw exception if user try to upload a pkcs1 format rsa private key. This fix will help to   allow user to upload pkcs1 format private key.   