### PR TITLE
fix vic plugin can not show in vc6.7u2

### DIFF
--- a/h5c/vic-service/src/main/resources/META-INF/MANIFEST.MF
+++ b/h5c/vic-service/src/main/resources/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Import-Package: com.google.gson;version="2.3.1",
  javax.net.ssl;version=0,
  javax.servlet.http;version="3.0",
  org.apache.commons.logging;version="1.1.1",
- org.springframework.beans.factory.annotation;version="[3.1.4,4.3.17.RELEASE_VMWARE]",
- org.springframework.http;version="[3.1.4,4.3.17.RELEASE_VMWARE]",
- org.springframework.stereotype;version="[3.1.4,4.3.17.RELEASE_VMWARE]",
- org.springframework.web.bind.annotation;version="[3.1.4,4.3.17.RELEASE_VMWARE]"
+ org.springframework.beans.factory.annotation,
+ org.springframework.http,
+ org.springframework.stereotype,
+ org.springframework.web.bind.annotation

--- a/h5c/vic/src/main/webapp/META-INF/MANIFEST.MF
+++ b/h5c/vic/src/main/webapp/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Import-Package: com.vmware.vic.mvc;version="1.0.0",
  com.vmware.vise.data.query;version=0,
  com.vmware.vise.security;version=0,
  org.eclipse.virgo.web.dm;version="[3.6.0,4)",
- org.springframework.web.servlet;version="[3.1.4,4.3.17.RELEASE_VMWARE]",
- org.springframework.web.servlet.config;version="[3.1.4,4.3.17.RELEASE_VMWARE]",
- org.springframework.web.servlet.view;version="[3.1.4,4.3.17.RELEASE_VMWARE]",
- org.springframework.web.servlet.view.json;version="[3.1.4,4.3.17.RELEASE_VMWARE]"
+ org.springframework.web.servlet,
+ org.springframework.web.servlet.config,
+ org.springframework.web.servlet.view,
+ org.springframework.web.servlet.view.json


### PR DESCRIPTION
in vc 6.7 u2, many lib package upgraded, that lead to we need to modify MANIFEST files  to remove the version control to let vc load new packages after upgrade. 