### PR TITLE
fix link mode can not get appliance error

### DIFF
--- a/h5c/vic-service/src/main/java/com/vmware/vic/PropFetcher.java
+++ b/h5c/vic-service/src/main/java/com/vmware/vic/PropFetcher.java
@@ -188,7 +188,7 @@ public class PropFetcher implements ClientSessionEndListener {
      * @return ResultItem object containing either VCH VM(s) or Container VM(s)
      *         based on the isVch boolean value
      */
-    public ResultItem getVicVms(boolean isVch) {
+    synchronized public ResultItem getVicVms(boolean isVch) {
         List<PropertyValue> pvList = new ArrayList<PropertyValue>();
         ResultItem resultItem = new ResultItem();
 
@@ -390,7 +390,7 @@ public class PropFetcher implements ClientSessionEndListener {
      * @throws RuntimeFaultFaultMsg
      * @throws InvalidPropertyFaultMsg
      */
-    public List<String> getVicApplianceVms()
+    synchronized public List<String> getVicApplianceVms()
             throws RuntimeFaultFaultMsg, InvalidPropertyFaultMsg {
         ArrayList<String> vicAppliancesList = new ArrayList<String>();
         UserSession userSession = _userSessionService.getUserSession();


### PR DESCRIPTION
In sumarry and vch page. Many apis are invoked concurrently to get the container and vch information
In our code 
private Root getRootObject() 
This api will get VCH and container information. They invoke the same method. and create container view to get exproperties from vc. We need to add synchronized key in the  ResultItem getVicVms(boolean isVch)  in PropFetcher.java