### PR TITLE
Fix linkmode create vch and delete vch will report wrong password and user name error

### DIFF
--- a/h5c/vic-service/src/main/java/com/vmware/vic/PropFetcher.java
+++ b/h5c/vic-service/src/main/java/com/vmware/vic/PropFetcher.java
@@ -683,7 +683,7 @@ public class PropFetcher implements ClientSessionEndListener {
      * @param serverGuid
      * @return ServiceContent object corresponding to the specified serverGuid
      */
-    private ServiceContent getServiceContent(String serverGuid) {
+    synchronized private ServiceContent getServiceContent(String serverGuid) {
         ServerInfo serverInfoObject = getServerInfoObject(serverGuid);
         setThumbprint(serverInfoObject);
         String sessionCookie = serverInfoObject.sessionCookie;
@@ -722,7 +722,7 @@ public class PropFetcher implements ClientSessionEndListener {
      * Obtain a clone ticket from vSphere
      * @throws Exception
      */
-    public String acquireCloneTicket(String serviceGuid) throws Exception {
+    synchronized public String acquireCloneTicket(String serviceGuid) throws Exception {
 
         ServerInfo[] sInfos = _userSessionService.getUserSession().serversInfo;
 


### PR DESCRIPTION
fix link mode create vch and delete vch will have 400 wrong user name and password error. create clone ticket need to use synchronised keyword to the invoke function. vc will not close the session. We need to investigate why will happen this. This will be the future work