### PR TITLE
fix issue for window certificate has /r charactor in file

### DIFF
--- a/h5c/vic/src/vic-webapp/src/app/shared/utils/certificates.ts
+++ b/h5c/vic/src/vic-webapp/src/app/shared/utils/certificates.ts
@@ -50,7 +50,7 @@ const algorithmsMap = {
 export function parseCertificatePEMFileContent(str: string): CertificateInfo {
 
   // Remove headers
-  str = str.replace(/(-----(BEGIN|END) CERTIFICATE-----|\n)/g, '');
+  str = str.replace(/(-----(BEGIN|END) CERTIFICATE-----|\r\n|\n)/g, '');
 
   // Decode Base64 string, convert to an ArrayBuffer and parse raw data
   const asn1 = fromBER(stringToArrayBuffer(fromBase64(str)));
@@ -66,10 +66,10 @@ export function parseCertificatePEMFileContent(str: string): CertificateInfo {
 export function parsePrivateKeyPEMFileContent(str: string): PrivateKeyInfo {
   // Remove headers
   if (str.indexOf('RSA PRIVATE KEY') !== -1) {
-    str = str.replace(/(-----(BEGIN|END) RSA PRIVATE KEY-----|\n)/g, '');
+    str = str.replace(/(-----(BEGIN|END) RSA PRIVATE KEY-----|\r\n|\n)/g, '');
     return { algorithm: 'RSA' };
   }
-  str = str.replace(/(-----(BEGIN|END) PRIVATE KEY-----|\n)/g, '');
+  str = str.replace(/(-----(BEGIN|END) PRIVATE KEY-----|\r\n|\n)/g, '');
   // Decode Base64 string, convert to an ArrayBuffer and parse raw data
   const asn1 = fromBER(stringToArrayBuffer(fromBase64(str)));
   // Create Private Key model


### PR DESCRIPTION
Some of the windows user which use openssl generated certificate has different line ending with linux. 
For linux the line ending will use: /n
For windows the line ending will use: /r/n. 
therefore, we need to also handle windows scenario to support filter out the beginning string and end string. 