### PR TITLE
change the ip address of appliance to fqdn

### DIFF
--- a/h5c/vic-service/src/main/java/com/vmware/vic/PropFetcher.java
+++ b/h5c/vic-service/src/main/java/com/vmware/vic/PropFetcher.java
@@ -17,6 +17,8 @@ limitations under the License.
  */
 package com.vmware.vic;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -441,8 +443,21 @@ public class PropFetcher implements ClientSessionEndListener {
                 if (props != null) {
                     for (ObjectContent objC : props.getObjects()) {
                         VicApplianceVm applianceVm = new VicApplianceVm(objC);
-                        vicAppliancesList.add(
-                                applianceVm.getName() + ": " + applianceVm.getVersionString() + "," + applianceVm.getIpAddress());
+                        String ip = applianceVm.getIpAddress();
+                        String hostnameCanonical = "";
+						try {
+							InetAddress address = InetAddress.getByName(ip);
+							hostnameCanonical = address.getCanonicalHostName();
+	                       
+						} catch (UnknownHostException e) {
+							hostnameCanonical = ip;
+							// TODO Auto-generated catch block
+							e.printStackTrace();
+						}
+						
+					    vicAppliancesList.add(
+	                                applianceVm.getName() + ": " + applianceVm.getVersionString() + "," + hostnameCanonical);
+                        
                     }
                 }
             } catch (RuntimeFaultFaultMsg | InvalidPropertyFaultMsg e) {

--- a/h5c/vic/src/vic-webapp/src/app/summary-view/summary-view.component.html
+++ b/h5c/vic/src/vic-webapp/src/app/summary-view/summary-view.component.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <span class="summary-label">
-            IP Address
+            Host
           </span>
           <span class="summary-value">
             <a target="_blank" href="{{'https://'+applianceIp+':9443'}}">{{applianceIp}}</a>


### PR DESCRIPTION
change the get appliance api return fqdn instead of ip address to avoid some users can not access the ip address , because certificate only work for fqdn access. 
Therefore to keep consistency, frontend also changed the summary page to show fqdn instead of ip. 
![image](https://user-images.githubusercontent.com/4946616/56006929-614c7400-5d09-11e9-852f-a70d830f5ac3.png)
