### PR TITLE
fix certificate chain will not show vic plugin

### DIFF
--- a/h5c/vic-service/src/main/java/com/vmware/utils/ssl/ThumbprintHostNameVerifier.java
+++ b/h5c/vic-service/src/main/java/com/vmware/utils/ssl/ThumbprintHostNameVerifier.java
@@ -10,23 +10,26 @@ import java.security.cert.X509Certificate;
 
 public class ThumbprintHostNameVerifier implements HostnameVerifier {
 
-   @Override
-   public boolean verify(String host, SSLSession session) {
-      try {
-         Certificate[] certificates = session.getPeerCertificates();
-         verify(host, (X509Certificate) certificates[0]);
-         return true;
-      } catch (SSLException e) {
-         return false;
-      }
-   }
+    @Override
+    public boolean verify(String host, SSLSession session) {
+        try {
+            Certificate[] certificates = session.getPeerCertificates();
+            verify(host, (X509Certificate) certificates[0]);
+            return true;
+        } catch (SSLException e) {
+            return false;
+        }
+    }
 
-   private void verify(String host, X509Certificate cert) throws SSLException {
-      try {
-         String thumbprint = ThumbprintTrustManager.getThumbprint(cert);
-         ThumbprintTrustManager.checkThumbprint(thumbprint);
-      } catch(CertificateException e){
-         throw new SSLException(e.getMessage());
-      }
-   }
+    private void verify(String host, X509Certificate cert) throws SSLException {
+        try {
+            String thumbprint = ThumbprintTrustManager.getThumbprint(cert);
+            boolean hasThumbprint = ThumbprintTrustManager.checkThumbprint(thumbprint);
+            if (!hasThumbprint) {
+                throw new SSLException("Server certificate chain is not trusted and thumbprint doesn't match");
+            }
+        } catch (CertificateException e) {
+            throw new SSLException(e.getMessage());
+        }
+    }
 }

--- a/h5c/vic-service/src/main/java/com/vmware/utils/ssl/ThumbprintTrustManager.java
+++ b/h5c/vic-service/src/main/java/com/vmware/utils/ssl/ThumbprintTrustManager.java
@@ -10,67 +10,82 @@ import java.security.cert.CertificateException;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.net.ssl.SSLException;
+
 public class ThumbprintTrustManager implements javax.net.ssl.TrustManager, javax.net.ssl.X509TrustManager {
 
-   private static final Log _logger = LogFactory.getLog(ThumbprintTrustManager.class);
-   private static Set<String> _thumbprints = new HashSet<String>();
+    private static final Log _logger = LogFactory.getLog(ThumbprintTrustManager.class);
+    private static Set<String> _thumbprints = new HashSet<String>();
 
-   public static void setThumbprints(Set<String> thumbprints) {
-	   synchronized(ThumbprintTrustManager.class) {
-		   _thumbprints = thumbprints;
-	   }
-   }
+    public static void setThumbprints(Set<String> thumbprints) {
+        synchronized (ThumbprintTrustManager.class) {
+            _thumbprints = thumbprints;
+        }
+    }
 
-   @Override
-   public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-      return null;
-   }
+    @Override
+    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+        return null;
+    }
 
-   @Override
-   public void checkServerTrusted(java.security.cert.X509Certificate[] certs,
-                                  String authType) throws CertificateException {
-      for (java.security.cert.X509Certificate cert : certs) {
-         String thumbprint = getThumbprint(cert);
-         checkThumbprint(thumbprint);
-      }
-   }
-
-   @Override
-   public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType) throws CertificateException {
-      return;
-   }
-
-   public static String getThumbprint(java.security.cert.X509Certificate cert) throws java.security.cert.CertificateException {
-      try {
-         MessageDigest md = MessageDigest.getInstance("SHA-1");
-         byte[] certBytes = cert.getEncoded();
-         byte[] bytes = md.digest(certBytes);
-
-         StringBuilder builder = new StringBuilder();
-         for (byte b : bytes) {
-            String hex = Integer.toHexString(0xFF & b);
-            if (hex.length() == 1) {
-               builder.append("0");
+    @Override
+    public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType)
+            throws CertificateException {
+        boolean isContainCert = false;
+        for (java.security.cert.X509Certificate cert : certs) {
+            String thumbprint = getThumbprint(cert);
+            if (checkThumbprint(thumbprint)) {
+                isContainCert = true;
+                break;
             }
-            builder.append(hex);
-         }
-         return builder.toString().toLowerCase();
-      } catch (NoSuchAlgorithmException ex) {
-         return null;
-      }
-   }
+        }
 
-   public static void checkThumbprint(String thumbprint) throws CertificateException {
-	   synchronized(ThumbprintTrustManager.class) {
-		   if (_thumbprints.contains(thumbprint)) {
-			   _logger.info("expected one of this thumbprints: " +_thumbprints + "\n" + "actual thumbprint: " + "["+thumbprint+"]" 
-					   + "...thumbprints matching ok!");
-			   return;
-		   }
-		   
-		   _logger.error("Server certificate chain is not trusted " + "and thumbprint doesn't match\n" + "expected one " + "of this "
-				   + _thumbprints + "\n" + "actual: " + "["+ thumbprint +"]" + "...matching failed!!");
-		   throw new CertificateException("Server certificate chain is not trusted " + "and thumbprint doesn't match");
-	   }
-   }
+        if (!isContainCert) {
+            throw new CertificateException("Server certificate chain is not trusted and thumbprint doesn't match");
+        }
+
+    }
+
+    @Override
+    public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType)
+            throws CertificateException {
+        return;
+    }
+
+    public static String getThumbprint(java.security.cert.X509Certificate cert)
+            throws java.security.cert.CertificateException {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            byte[] certBytes = cert.getEncoded();
+            byte[] bytes = md.digest(certBytes);
+
+            StringBuilder builder = new StringBuilder();
+            for (byte b : bytes) {
+                String hex = Integer.toHexString(0xFF & b);
+                if (hex.length() == 1) {
+                    builder.append("0");
+                }
+                builder.append(hex);
+            }
+            return builder.toString().toLowerCase();
+        } catch (NoSuchAlgorithmException ex) {
+            return null;
+        }
+    }
+
+    public static boolean checkThumbprint(String thumbprint) {
+        synchronized (ThumbprintTrustManager.class) {
+            if (_thumbprints.contains(thumbprint)) {
+                _logger.info("expected one of this thumbprints: " + _thumbprints + "\n" + "actual thumbprint: " + "["
+                        + thumbprint + "]" + "...thumbprints matching ok!");
+                return true;
+            }
+
+            _logger.error("Server certificate chain is not trusted " + "and thumbprint doesn't match\n"
+                    + "expected one " + "of this " + _thumbprints + "\n" + "actual: " + "[" + thumbprint + "]"
+                    + "...matching failed!!");
+            return false;
+
+        }
+    }
 }


### PR DESCRIPTION
In certificate chain environment. Java ssl trustManager will get multiple certs in the backend. 
The old logic will suppose each certs will be in the vcenter server info thumbprint sets. Actually, in this case only one cert thumbprint will in the thumbprint sets. So this logic need to be updated. Modify the logic to suppose vcenter sets will match any of the cert thumbprint from session. If none of the cert thumbprint match the vcenter thumbprint , then throw the exception. 