### PR TITLE
Support vic ui plugin running on vc 7.0.2

### DIFF
--- a/h5c/vic-service/src/main/java/com/vmware/vic/PropFetcher.java
+++ b/h5c/vic-service/src/main/java/com/vmware/vic/PropFetcher.java
@@ -32,6 +32,9 @@ import java.util.Set;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.TrustManager;
 import javax.xml.ws.BindingProvider;
 import javax.xml.ws.handler.MessageContext;
 
@@ -103,26 +106,28 @@ public class PropFetcher implements ClientSessionEndListener {
         HostnameVerifier hostNameVerifier = new ThumbprintHostNameVerifier();
         HttpsURLConnection.setDefaultHostnameVerifier(hostNameVerifier);
 
-        javax.net.ssl.TrustManager[] tms = new javax.net.ssl.TrustManager[1];
-        javax.net.ssl.TrustManager tm = new ThumbprintTrustManager();
-        tms[0] = tm;
-        javax.net.ssl.SSLContext sc = null;
+        TrustManager[] trustManagers = new TrustManager[1];
+        TrustManager trustManager = new ThumbprintTrustManager();
+        trustManagers[0] = trustManager;
+        SSLContext sslContext = null;
 
         try {
-            sc = javax.net.ssl.SSLContext.getInstance("SSL");
+            sslContext = SSLContext.getInstance("TLS");
         } catch (NoSuchAlgorithmException e) {
             _logger.error(e);
         }
 
-        if (null != sc) {
-            javax.net.ssl.SSLSessionContext sslsc = sc.getServerSessionContext();
-            sslsc.setSessionTimeout(0);
+        if (null != sslContext) {
             try {
-                sc.init(null, tms, null);
+                sslContext.init(null, trustManagers, null);
             } catch (KeyManagementException e) {
                 _logger.error(e);
             }
-            javax.net.ssl.HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+
+            SSLSessionContext sslSessionContext = sslContext.getServerSessionContext();
+            sslSessionContext.setSessionTimeout(0);
+
+            HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
         }
     }
 


### PR DESCRIPTION
Current VIC UI plugin can not be shown up on vsphere-client7.0.2 due to new security requirements.
For fix this issue, we need to change protocol from 'SSL' to 'TLS'.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic-ui/blob/master/.github/CONTRIBUTING.md
-->

Fixes #696

PR acceptance checklist:

[ ] All unit tests pass
[ ] All e2e tests pass
[] Unit test(s) included*
[n/a ] e2e test(s) included*
[n/a] Screenshot attached and UX approved*

 *if applicable, add n/a if not
